### PR TITLE
test: add basic unit test suite for @formstr/sdk

### DIFF
--- a/packages/formstr-sdk/jest.config.js
+++ b/packages/formstr-sdk/jest.config.js
@@ -5,4 +5,10 @@ module.exports = {
     "^.+\\.(t|j)s?$": "ts-jest",
   },
   transformIgnorePatterns: ["<rootDir>/node_modules/"],
+  moduleNameMapper: {
+    // The SDK source uses ESM-style .js extensions in imports
+    // (e.g. "./pool.js", "./utils/fetchFormTemplate.js").
+    // ts-jest resolves .ts files, so we strip the .js suffix here.
+    "^(\\.\\.?/.*)\\.js$": "$1",
+  },
 };

--- a/packages/formstr-sdk/src/sdk/__tests__/fetchFormTemplate.test.ts
+++ b/packages/formstr-sdk/src/sdk/__tests__/fetchFormTemplate.test.ts
@@ -1,0 +1,223 @@
+// We need to mock SimplePool before importing fetchFormTemplate
+const mockGet = jest.fn();
+jest.mock("nostr-tools", () => {
+  const actual = jest.requireActual("nostr-tools");
+  return {
+    ...actual,
+    SimplePool: jest.fn().mockImplementation(() => ({
+      get: mockGet,
+    })),
+  };
+});
+
+import { fetchFormTemplate, getDefaultRelays } from "../utils/fetchFormTemplate";
+import { nip19 } from "nostr-tools";
+import type { AddressPointer } from "nostr-tools/lib/types/nip19";
+
+describe("getDefaultRelays", () => {
+  it("returns an array of relay URLs", () => {
+    const relays = getDefaultRelays();
+    expect(Array.isArray(relays)).toBe(true);
+    expect(relays.length).toBeGreaterThan(0);
+  });
+
+  it("all relay URLs start with wss://", () => {
+    const relays = getDefaultRelays();
+    relays.forEach((url) => {
+      expect(url).toMatch(/^wss:\/\//);
+    });
+  });
+
+  it("returns the same array on repeated calls (stable reference)", () => {
+    const a = getDefaultRelays();
+    const b = getDefaultRelays();
+    expect(a).toEqual(b);
+  });
+});
+
+describe("fetchFormTemplate", () => {
+  // Build a valid naddr for testing
+  const testPubkey = "a".repeat(64);
+  const testIdentifier = "test-form-id";
+  const testRelays = ["wss://relay.damus.io/"];
+
+  const testNaddr = nip19.naddrEncode({
+    pubkey: testPubkey,
+    kind: 30168,
+    identifier: testIdentifier,
+    relays: testRelays,
+  });
+
+  const noRelayNaddr = nip19.naddrEncode({
+    pubkey: testPubkey,
+    kind: 30168,
+    identifier: testIdentifier,
+    relays: [],
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns tags from a public (unencrypted) form event", async () => {
+    const mockEvent = {
+      kind: 30168,
+      pubkey: testPubkey,
+      content: "",
+      tags: [
+        ["d", testIdentifier],
+        ["name", "Test Form"],
+        ["field", "q1", "text", "Your Name", "", "{}"],
+        ["relay", "wss://relay.damus.io/"],
+      ],
+      created_at: 1000,
+      id: "event-id",
+      sig: "event-sig",
+    };
+
+    mockGet.mockResolvedValueOnce(mockEvent);
+    const result = await fetchFormTemplate(testNaddr);
+
+    expect(result).toBeDefined();
+    expect(result).not.toBeNull();
+    // Public form: should contain all original tags plus the pubkey tag
+    expect(result).toContainEqual(["d", testIdentifier]);
+    expect(result).toContainEqual(["name", "Test Form"]);
+    expect(result).toContainEqual(["pubkey", testPubkey]);
+  });
+
+  it("appends pubkey tag to returned tags for public forms", async () => {
+    const mockEvent = {
+      kind: 30168,
+      pubkey: testPubkey,
+      content: "",
+      tags: [
+        ["d", testIdentifier],
+        ["name", "Form"],
+      ],
+      created_at: 1000,
+      id: "event-id",
+      sig: "event-sig",
+    };
+
+    mockGet.mockResolvedValueOnce(mockEvent);
+    const result = await fetchFormTemplate(testNaddr);
+
+    const pubkeyTag = result!.find(
+      (t) => t[0] === "pubkey" && t[1] === testPubkey
+    );
+    expect(pubkeyTag).toBeDefined();
+  });
+
+  it("throws when event is not found on relays", async () => {
+    mockGet.mockResolvedValueOnce(null);
+
+    await expect(fetchFormTemplate(testNaddr)).rejects.toThrow(
+      /Event not found on given relays/
+    );
+  });
+
+  it("throws when encrypted form has no nkeys provided", async () => {
+    const mockEvent = {
+      kind: 30168,
+      pubkey: testPubkey,
+      content: "encrypted-content-here",
+      tags: [
+        ["d", testIdentifier],
+        ["name", "Private Form"],
+      ],
+      created_at: 1000,
+      id: "event-id",
+      sig: "event-sig",
+    };
+
+    mockGet.mockResolvedValueOnce(mockEvent);
+
+    // No nkeys provided
+    await expect(fetchFormTemplate(testNaddr)).rejects.toThrow(
+      /Could not decrypt form/
+    );
+  });
+
+  it("queries the pool with correct filter", async () => {
+    const mockEvent = {
+      kind: 30168,
+      pubkey: testPubkey,
+      content: "",
+      tags: [["d", testIdentifier]],
+      created_at: 1000,
+      id: "event-id",
+      sig: "event-sig",
+    };
+
+    mockGet.mockResolvedValueOnce(mockEvent);
+    await fetchFormTemplate(testNaddr);
+
+    expect(mockGet).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.objectContaining({
+        kinds: [30168],
+        authors: [testPubkey],
+        "#d": [testIdentifier],
+      })
+    );
+  });
+
+  it("uses relays from naddr when available", async () => {
+    const mockEvent = {
+      kind: 30168,
+      pubkey: testPubkey,
+      content: "",
+      tags: [["d", testIdentifier]],
+      created_at: 1000,
+      id: "event-id",
+      sig: "event-sig",
+    };
+
+    mockGet.mockResolvedValueOnce(mockEvent);
+    await fetchFormTemplate(testNaddr);
+
+    const usedRelays = mockGet.mock.calls[0][0];
+    expect(usedRelays).toContain("wss://relay.damus.io/");
+  });
+
+  it("falls back to default relays when naddr has no relays", async () => {
+    const mockEvent = {
+      kind: 30168,
+      pubkey: testPubkey,
+      content: "",
+      tags: [["d", testIdentifier]],
+      created_at: 1000,
+      id: "event-id",
+      sig: "event-sig",
+    };
+
+    mockGet.mockResolvedValueOnce(mockEvent);
+    await fetchFormTemplate(noRelayNaddr);
+
+    const usedRelays = mockGet.mock.calls[0][0];
+    expect(usedRelays).toEqual(getDefaultRelays());
+  });
+
+  it("preserves relay tags from the event for public forms", async () => {
+    const mockEvent = {
+      kind: 30168,
+      pubkey: testPubkey,
+      content: "",
+      tags: [
+        ["d", testIdentifier],
+        ["relay", "wss://relay.damus.io/"],
+        ["relay", "wss://nos.lol"],
+      ],
+      created_at: 1000,
+      id: "event-id",
+      sig: "event-sig",
+    };
+
+    mockGet.mockResolvedValueOnce(mockEvent);
+    const result = await fetchFormTemplate(testNaddr);
+
+    const relayTags = result!.filter((t) => t[0] === "relay");
+    expect(relayTags).toHaveLength(2);
+  });
+});

--- a/packages/formstr-sdk/src/sdk/__tests__/helper.test.ts
+++ b/packages/formstr-sdk/src/sdk/__tests__/helper.test.ts
@@ -1,0 +1,137 @@
+import { stripHtml, getOrderedFieldIds } from "../utils/helper";
+import { NormalizedForm, SectionData } from "../types";
+
+describe("stripHtml", () => {
+  it("returns empty string for undefined input", () => {
+    expect(stripHtml(undefined)).toBe("");
+  });
+
+  it("returns empty string for empty string input", () => {
+    expect(stripHtml("")).toBe("");
+  });
+
+  it("returns plain text unchanged", () => {
+    expect(stripHtml("Hello World")).toBe("Hello World");
+  });
+
+  it("strips simple HTML tags", () => {
+    expect(stripHtml("<b>bold</b>")).toBe("bold");
+  });
+
+  it("strips nested HTML tags", () => {
+    expect(stripHtml("<div><p>Hello <strong>World</strong></p></div>")).toBe(
+      "Hello World"
+    );
+  });
+
+  it("strips self-closing tags", () => {
+    expect(stripHtml("Line1<br/>Line2")).toBe("Line1Line2");
+  });
+
+  it("strips tags with attributes", () => {
+    expect(stripHtml('<a href="https://example.com">Link</a>')).toBe("Link");
+  });
+
+  it("normalizes multiple whitespace to single space", () => {
+    expect(stripHtml("Hello    World")).toBe("Hello World");
+  });
+
+  it("trims leading and trailing whitespace", () => {
+    expect(stripHtml("  Hello World  ")).toBe("Hello World");
+  });
+
+  it("handles mixed HTML, extra whitespace, and trimming", () => {
+    expect(stripHtml("  <p>  Hello  <b>World</b>  </p>  ")).toBe(
+      "Hello World"
+    );
+  });
+
+  it("handles script tags (strips them as text)", () => {
+    expect(stripHtml('<script>alert("xss")</script>')).toBe('alert("xss")');
+  });
+
+  it("handles empty tags", () => {
+    expect(stripHtml("<p></p><div></div>")).toBe("");
+  });
+});
+
+describe("getOrderedFieldIds", () => {
+  const makeForm = (
+    fieldOrder: string[],
+    sections?: SectionData[]
+  ): NormalizedForm => ({
+    id: "test",
+    name: "Test Form",
+    pubkey: "abc",
+    fields: {},
+    fieldOrder,
+    sections,
+    relays: [],
+    settings: {},
+  });
+
+  it("returns fieldOrder when no sections exist", () => {
+    const form = makeForm(["q1", "q2", "q3"]);
+    expect(getOrderedFieldIds(form)).toEqual(["q1", "q2", "q3"]);
+  });
+
+  it("returns fieldOrder when sections array is empty", () => {
+    const form = makeForm(["q1", "q2", "q3"], []);
+    expect(getOrderedFieldIds(form)).toEqual(["q1", "q2", "q3"]);
+  });
+
+  it("returns fields ordered by section order", () => {
+    const form = makeForm(["q1", "q2", "q3", "q4"], [
+      {
+        id: "s2",
+        title: "Section 2",
+        questionIds: ["q3", "q4"],
+        order: 2,
+      },
+      {
+        id: "s1",
+        title: "Section 1",
+        questionIds: ["q1", "q2"],
+        order: 1,
+      },
+    ]);
+    // Should sort by order: s1 (order=1) then s2 (order=2)
+    expect(getOrderedFieldIds(form)).toEqual(["q1", "q2", "q3", "q4"]);
+  });
+
+  it("respects section order regardless of array position", () => {
+    const form = makeForm(["q1", "q2", "q3"], [
+      {
+        id: "s3",
+        title: "Third",
+        questionIds: ["q3"],
+        order: 10,
+      },
+      {
+        id: "s1",
+        title: "First",
+        questionIds: ["q1"],
+        order: 0,
+      },
+      {
+        id: "s2",
+        title: "Second",
+        questionIds: ["q2"],
+        order: 5,
+      },
+    ]);
+    expect(getOrderedFieldIds(form)).toEqual(["q1", "q2", "q3"]);
+  });
+
+  it("handles single section", () => {
+    const form = makeForm(["q1", "q2"], [
+      {
+        id: "s1",
+        title: "Only",
+        questionIds: ["q1", "q2"],
+        order: 0,
+      },
+    ]);
+    expect(getOrderedFieldIds(form)).toEqual(["q1", "q2"]);
+  });
+});

--- a/packages/formstr-sdk/src/sdk/__tests__/nkeys.test.ts
+++ b/packages/formstr-sdk/src/sdk/__tests__/nkeys.test.ts
@@ -1,0 +1,104 @@
+import { encodeNKeys, decodeNKeys } from "../utils/nkeys";
+
+describe("NKeys encoding/decoding", () => {
+  describe("encodeNKeys", () => {
+    it("returns a string starting with 'nkeys1'", () => {
+      const encoded = encodeNKeys({ viewKey: "abc123" });
+      expect(encoded).toMatch(/^nkeys1/);
+    });
+
+    it("encodes a single key-value pair", () => {
+      const encoded = encodeNKeys({ viewKey: "deadbeef" });
+      expect(typeof encoded).toBe("string");
+      expect(encoded.length).toBeGreaterThan(6); // "nkeys1" + data
+    });
+
+    it("encodes multiple key-value pairs", () => {
+      const encoded = encodeNKeys({
+        viewKey: "deadbeef",
+        editKey: "cafebabe",
+      });
+      expect(typeof encoded).toBe("string");
+      expect(encoded.length).toBeGreaterThan(6);
+    });
+  });
+
+  describe("decodeNKeys", () => {
+    it("round-trips a single key-value pair", () => {
+      const original = { viewKey: "deadbeef" };
+      const encoded = encodeNKeys(original);
+      const decoded = decodeNKeys(encoded);
+      expect(decoded).toEqual(original);
+    });
+
+    it("round-trips multiple key-value pairs", () => {
+      const original = {
+        viewKey: "deadbeef",
+        editKey: "cafebabe",
+      };
+      const encoded = encodeNKeys(original);
+      const decoded = decodeNKeys(encoded);
+      expect(decoded).toEqual(original);
+    });
+
+    it("round-trips a secretKey + viewKey combination", () => {
+      const original = {
+        viewKey: "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
+        secretKey: "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+      };
+      const encoded = encodeNKeys(original);
+      const decoded = decodeNKeys(encoded);
+      expect(decoded).toEqual(original);
+    });
+
+    it("round-trips keys with empty string values", () => {
+      const original = { viewKey: "" };
+      const encoded = encodeNKeys(original);
+      const decoded = decodeNKeys(encoded);
+      expect(decoded).toEqual(original);
+    });
+
+    it("round-trips keys with special characters", () => {
+      const original = { myKey: "hello-world_123/test" };
+      const encoded = encodeNKeys(original);
+      const decoded = decodeNKeys(encoded);
+      expect(decoded).toEqual(original);
+    });
+
+    it("round-trips keys with unicode text", () => {
+      const original = { label: "日本語テスト" };
+      const encoded = encodeNKeys(original);
+      const decoded = decodeNKeys(encoded);
+      expect(decoded).toEqual(original);
+    });
+  });
+
+  describe("determinism", () => {
+    it("produces the same output for the same input", () => {
+      const input = { viewKey: "deadbeef", secretKey: "cafebabe" };
+      const first = encodeNKeys(input);
+      const second = encodeNKeys(input);
+      expect(first).toBe(second);
+    });
+  });
+
+  describe("error handling", () => {
+    it("throws on invalid bech32 string", () => {
+      expect(() => decodeNKeys("invalid-string")).toThrow();
+    });
+
+    it("throws on wrong bech32 prefix", () => {
+      // npub is valid bech32 but wrong prefix — bech32 decode will still work,
+      // but the TLV data will be garbage. decodeNKeys should not crash but
+      // may return incorrect/empty data. It should at minimum not throw.
+      // This tests robustness of the TLV parser.
+      expect(() => {
+        try {
+          decodeNKeys("nkeys1invaliddata");
+        } catch {
+          throw new Error("decode failed");
+        }
+      }).toThrow();
+    });
+  });
+});

--- a/packages/formstr-sdk/src/sdk/__tests__/normalizeForm.test.ts
+++ b/packages/formstr-sdk/src/sdk/__tests__/normalizeForm.test.ts
@@ -1,0 +1,388 @@
+import { FormstrSDK } from "../FormstrSDK";
+import type { Tag } from "../types";
+
+const sdk = new FormstrSDK();
+
+/**
+ * Helpers for building NIP-101 tag arrays
+ */
+function makeTags(overrides: {
+  id?: string;
+  name?: string;
+  settings?: object;
+  pubkey?: string;
+  relays?: string[];
+  fields?: Tag[];
+}): Tag[] {
+  const tags: Tag[] = [];
+  if (overrides.id) tags.push(["d", overrides.id]);
+  if (overrides.name) tags.push(["name", overrides.name]);
+  if (overrides.settings)
+    tags.push(["settings", JSON.stringify(overrides.settings)]);
+  if (overrides.pubkey) tags.push(["pubkey", overrides.pubkey]);
+  if (overrides.relays)
+    overrides.relays.forEach((r) => tags.push(["relay", r]));
+  if (overrides.fields) tags.push(...overrides.fields);
+  return tags;
+}
+
+describe("FormstrSDK.normalizeForm", () => {
+  describe("basic form metadata", () => {
+    it("extracts form id from d tag", () => {
+      const form = sdk.normalizeForm(makeTags({ id: "my-form-123" }));
+      expect(form.id).toBe("my-form-123");
+    });
+
+    it("returns empty id when d tag is missing", () => {
+      const form = sdk.normalizeForm(makeTags({ name: "Test" }));
+      expect(form.id).toBe("");
+    });
+
+    it("extracts form name and strips HTML", () => {
+      const form = sdk.normalizeForm(
+        makeTags({ name: "<b>My Form</b>" })
+      );
+      expect(form.name).toBe("My Form");
+    });
+
+    it("returns empty name when name tag is missing", () => {
+      const form = sdk.normalizeForm(makeTags({ id: "test" }));
+      expect(form.name).toBe("");
+    });
+
+    it("extracts pubkey from pubkey tag", () => {
+      const form = sdk.normalizeForm(
+        makeTags({ pubkey: "deadbeefcafebabe" })
+      );
+      expect(form.pubkey).toBe("deadbeefcafebabe");
+    });
+
+    it("returns empty pubkey when pubkey tag is missing", () => {
+      const form = sdk.normalizeForm(makeTags({ id: "test" }));
+      expect(form.pubkey).toBe("");
+    });
+
+    it("extracts relay URLs", () => {
+      const form = sdk.normalizeForm(
+        makeTags({
+          relays: ["wss://relay.damus.io/", "wss://nos.lol"],
+        })
+      );
+      expect(form.relays).toEqual(["wss://relay.damus.io/", "wss://nos.lol"]);
+    });
+
+    it("returns empty relay list when no relay tags exist", () => {
+      const form = sdk.normalizeForm(makeTags({ id: "test" }));
+      expect(form.relays).toEqual([]);
+    });
+  });
+
+  describe("settings parsing", () => {
+    it("parses settings JSON from settings tag", () => {
+      const settings = { description: "A test form", encryptForm: true };
+      const form = sdk.normalizeForm(makeTags({ settings }));
+      expect(form.settings).toEqual(settings);
+    });
+
+    it("returns empty settings when settings tag is missing", () => {
+      const form = sdk.normalizeForm(makeTags({ id: "test" }));
+      expect(form.settings).toEqual({});
+    });
+  });
+
+  describe("field normalization", () => {
+    it("normalizes a text field", () => {
+      const form = sdk.normalizeForm(
+        makeTags({
+          id: "test",
+          fields: [
+            [
+              "field",
+              "q1",
+              "text",
+              "What is your name?",
+              "",
+              '{"required":true}',
+            ],
+          ],
+        })
+      );
+
+      expect(form.fields["q1"]).toBeDefined();
+      expect(form.fields["q1"].id).toBe("q1");
+      expect(form.fields["q1"].type).toBe("text");
+      expect(form.fields["q1"].labelHtml).toBe("What is your name?");
+      expect(form.fields["q1"].config).toEqual({ required: true });
+      expect(form.fieldOrder).toEqual(["q1"]);
+    });
+
+    it("normalizes an option field with choices", () => {
+      const options = JSON.stringify([
+        ["opt1", "Yes"],
+        ["opt2", "No"],
+      ]);
+      const form = sdk.normalizeForm(
+        makeTags({
+          fields: [
+            [
+              "field",
+              "q2",
+              "option",
+              "Do you agree?",
+              options,
+              '{"required":false}',
+            ],
+          ],
+        })
+      );
+
+      const field = form.fields["q2"];
+      expect(field.type).toBe("option");
+      expect(field.options).toHaveLength(2);
+      expect(field.options![0]).toEqual({ id: "opt1", labelHtml: "Yes", config: undefined });
+      expect(field.options![1]).toEqual({ id: "opt2", labelHtml: "No", config: undefined });
+    });
+
+    it("normalizes option choices with config", () => {
+      const options = JSON.stringify([
+        ["opt1", "Choice A", '{"isOther":true}'],
+      ]);
+      const form = sdk.normalizeForm(
+        makeTags({
+          fields: [
+            ["field", "q3", "option", "Pick one", options, "{}"],
+          ],
+        })
+      );
+
+      expect(form.fields["q3"].options![0].config).toEqual({
+        isOther: true,
+      });
+    });
+
+    it("normalizes a label field (no options)", () => {
+      const form = sdk.normalizeForm(
+        makeTags({
+          fields: [
+            ["field", "lbl1", "label", "Instructions here", "", "{}"],
+          ],
+        })
+      );
+
+      expect(form.fields["lbl1"].type).toBe("label");
+      expect(form.fields["lbl1"].labelHtml).toBe("Instructions here");
+      expect(form.fields["lbl1"].options).toBeUndefined();
+    });
+
+    it("preserves field order from tag array", () => {
+      const form = sdk.normalizeForm(
+        makeTags({
+          fields: [
+            ["field", "q1", "text", "First", "", "{}"],
+            ["field", "q2", "text", "Second", "", "{}"],
+            ["field", "q3", "text", "Third", "", "{}"],
+          ],
+        })
+      );
+
+      expect(form.fieldOrder).toEqual(["q1", "q2", "q3"]);
+    });
+
+    it("handles field with no options and no config strings", () => {
+      // When optionsStr is empty string (falsy) and configStr is empty
+      const form = sdk.normalizeForm([
+        ["field", "q1", "text", "Simple", "", ""],
+      ]);
+
+      expect(form.fields["q1"].options).toBeUndefined();
+      expect(form.fields["q1"].config).toEqual({});
+    });
+
+    it("strips HTML from field labels", () => {
+      const form = sdk.normalizeForm(
+        makeTags({
+          fields: [
+            [
+              "field",
+              "q1",
+              "text",
+              "<p>What is <b>your</b> name?</p>",
+              "",
+              "{}",
+            ],
+          ],
+        })
+      );
+      // labelHtml is the raw label — stripHtml is applied to options labels
+      // but the label itself is stored as-is in NormalizedField.labelHtml
+      expect(form.fields["q1"].labelHtml).toBe(
+        "<p>What is <b>your</b> name?</p>"
+      );
+    });
+
+    it("strips HTML from option labels", () => {
+      const options = JSON.stringify([["opt1", "<em>Bold Choice</em>"]]);
+      const form = sdk.normalizeForm(
+        makeTags({
+          fields: [
+            ["field", "q1", "option", "Pick", options, "{}"],
+          ],
+        })
+      );
+
+      expect(form.fields["q1"].options![0].labelHtml).toBe("Bold Choice");
+    });
+  });
+
+  describe("blocks generation", () => {
+    it("creates intro block when name tag exists", () => {
+      const form = sdk.normalizeForm(
+        makeTags({ name: "My Form" })
+      );
+
+      const intro = form.blocks!.find((b) => b.type === "intro");
+      expect(intro).toBeDefined();
+      expect(intro!.type).toBe("intro");
+      expect((intro as any).title).toBe("My Form");
+    });
+
+    it("creates intro block when description exists in settings", () => {
+      const form = sdk.normalizeForm(
+        makeTags({
+          settings: { description: "Fill out this form" },
+        })
+      );
+
+      const intro = form.blocks!.find((b) => b.type === "intro");
+      expect(intro).toBeDefined();
+      expect((intro as any).description).toBe("Fill out this form");
+    });
+
+    it("does not create intro block when neither name nor description exist", () => {
+      const form = sdk.normalizeForm(
+        makeTags({
+          id: "test",
+          fields: [["field", "q1", "text", "Question", "", "{}"]],
+        })
+      );
+
+      const intro = form.blocks!.find((b) => b.type === "intro");
+      expect(intro).toBeUndefined();
+    });
+
+    it("creates a default section block when no sections in settings", () => {
+      const form = sdk.normalizeForm(
+        makeTags({
+          fields: [
+            ["field", "q1", "text", "Q1", "", "{}"],
+            ["field", "q2", "text", "Q2", "", "{}"],
+          ],
+        })
+      );
+
+      const sections = form.blocks!.filter((b) => b.type === "section");
+      expect(sections).toHaveLength(1);
+      expect((sections[0] as any).id).toBe("default");
+      expect((sections[0] as any).questionIds).toEqual(["q1", "q2"]);
+    });
+
+    it("creates section blocks from settings.sections, sorted by order", () => {
+      const form = sdk.normalizeForm(
+        makeTags({
+          settings: {
+            sections: [
+              {
+                id: "s2",
+                title: "Part 2",
+                description: "Second part",
+                questionIds: ["q3"],
+                order: 2,
+              },
+              {
+                id: "s1",
+                title: "Part 1",
+                description: "First part",
+                questionIds: ["q1", "q2"],
+                order: 1,
+              },
+            ],
+          },
+          fields: [
+            ["field", "q1", "text", "Q1", "", "{}"],
+            ["field", "q2", "text", "Q2", "", "{}"],
+            ["field", "q3", "text", "Q3", "", "{}"],
+          ],
+        })
+      );
+
+      const sections = form.blocks!.filter((b) => b.type === "section");
+      expect(sections).toHaveLength(2);
+      // Should be sorted by order
+      expect((sections[0] as any).id).toBe("s1");
+      expect((sections[0] as any).title).toBe("Part 1");
+      expect((sections[0] as any).order).toBe(1);
+      expect((sections[1] as any).id).toBe("s2");
+      expect((sections[1] as any).title).toBe("Part 2");
+      expect((sections[1] as any).order).toBe(2);
+    });
+  });
+
+  describe("complete form normalization", () => {
+    it("normalizes a complete public form", () => {
+      const tags: Tag[] = [
+        ["d", "feedback-form"],
+        ["name", "Customer Feedback"],
+        [
+          "settings",
+          JSON.stringify({ description: "Please share your thoughts" }),
+        ],
+        ["pubkey", "abc123"],
+        ["relay", "wss://relay.damus.io/"],
+        ["relay", "wss://nos.lol"],
+        [
+          "field",
+          "q1",
+          "text",
+          "Your Name",
+          "",
+          '{"required":true}',
+        ],
+        [
+          "field",
+          "q2",
+          "option",
+          "Rate us",
+          JSON.stringify([
+            ["r1", "Good"],
+            ["r2", "Bad"],
+          ]),
+          '{"required":true}',
+        ],
+        ["field", "q3", "text", "Comments", "", '{"required":false}'],
+      ];
+
+      const form = sdk.normalizeForm(tags);
+
+      expect(form.id).toBe("feedback-form");
+      expect(form.name).toBe("Customer Feedback");
+      expect(form.pubkey).toBe("abc123");
+      expect(form.relays).toEqual(["wss://relay.damus.io/", "wss://nos.lol"]);
+      expect(form.fieldOrder).toEqual(["q1", "q2", "q3"]);
+      expect(Object.keys(form.fields)).toEqual(["q1", "q2", "q3"]);
+      expect(form.fields["q1"].config.required).toBe(true);
+      expect(form.fields["q2"].options).toHaveLength(2);
+      expect(form.blocks).toBeDefined();
+      expect(form.blocks!.length).toBeGreaterThanOrEqual(2); // intro + default section
+    });
+
+    it("normalizes minimal empty tags (edge case)", () => {
+      const form = sdk.normalizeForm([]);
+      expect(form.id).toBe("");
+      expect(form.name).toBe("");
+      expect(form.pubkey).toBe("");
+      expect(form.relays).toEqual([]);
+      expect(form.fieldOrder).toEqual([]);
+      expect(Object.keys(form.fields)).toEqual([]);
+    });
+  });
+});

--- a/packages/formstr-sdk/src/sdk/__tests__/renderHtml.test.ts
+++ b/packages/formstr-sdk/src/sdk/__tests__/renderHtml.test.ts
@@ -1,0 +1,322 @@
+import { FormstrSDK } from "../FormstrSDK";
+import type { NormalizedForm, NormalizedField, Tag } from "../types";
+
+const sdk = new FormstrSDK();
+
+/**
+ * Helper to build a NormalizedForm for renderHtml testing.
+ */
+function makeNormalizedForm(overrides: Partial<NormalizedForm> = {}): NormalizedForm {
+  return {
+    id: "test-form",
+    name: "Test Form",
+    pubkey: "abc123",
+    fields: {},
+    fieldOrder: [],
+    relays: [],
+    settings: {},
+    blocks: [],
+    ...overrides,
+  };
+}
+
+describe("FormstrSDK.renderHtml", () => {
+  describe("basic form structure", () => {
+    it("returns the form object with html property set", () => {
+      const form = makeNormalizedForm();
+      const result = sdk.renderHtml(form);
+      expect(result.html).toBeDefined();
+      expect(result.html!.form).toBeDefined();
+    });
+
+    it("wraps output in a <form> tag with correct id", () => {
+      const form = makeNormalizedForm({ id: "my-form" });
+      const result = sdk.renderHtml(form);
+      expect(result.html!.form).toContain('id="form-my-form"');
+    });
+
+    it("includes a submit button with correct id", () => {
+      const form = makeNormalizedForm({ id: "my-form" });
+      const result = sdk.renderHtml(form);
+      expect(result.html!.form).toContain('id="form-submit-my-form"');
+      expect(result.html!.form).toContain("Submit");
+    });
+  });
+
+  describe("text field rendering", () => {
+    it("renders a text input with label", () => {
+      const fields: Record<string, NormalizedField> = {
+        q1: {
+          id: "q1",
+          type: "text",
+          labelHtml: "Your Name",
+          config: {},
+        },
+      };
+      const form = makeNormalizedForm({
+        fields,
+        fieldOrder: ["q1"],
+        blocks: [
+          {
+            type: "section",
+            id: "default",
+            title: undefined,
+            description: undefined,
+            questionIds: ["q1"],
+            order: 0,
+          },
+        ],
+      });
+
+      const result = sdk.renderHtml(form);
+      expect(result.html!.form).toContain("<label>Your Name</label>");
+      expect(result.html!.form).toContain('type="text"');
+      expect(result.html!.form).toContain('name="q1"');
+    });
+  });
+
+  describe("option field rendering", () => {
+    it("renders radio buttons for option fields", () => {
+      const fields: Record<string, NormalizedField> = {
+        q1: {
+          id: "q1",
+          type: "option",
+          labelHtml: "Pick one",
+          options: [
+            { id: "opt1", labelHtml: "Yes" },
+            { id: "opt2", labelHtml: "No" },
+          ],
+          config: {},
+        },
+      };
+      const form = makeNormalizedForm({
+        fields,
+        fieldOrder: ["q1"],
+        blocks: [
+          {
+            type: "section",
+            id: "default",
+            title: undefined,
+            description: undefined,
+            questionIds: ["q1"],
+            order: 0,
+          },
+        ],
+      });
+
+      const result = sdk.renderHtml(form);
+      expect(result.html!.form).toContain('class="option-group"');
+      expect(result.html!.form).toContain("Pick one");
+      expect(result.html!.form).toContain('type="radio"');
+      expect(result.html!.form).toContain('value="opt1"');
+      expect(result.html!.form).toContain('value="opt2"');
+      expect(result.html!.form).toContain("Yes");
+      expect(result.html!.form).toContain("No");
+    });
+  });
+
+  describe("label field rendering", () => {
+    it("renders label fields as <p> tags", () => {
+      const fields: Record<string, NormalizedField> = {
+        lbl1: {
+          id: "lbl1",
+          type: "label",
+          labelHtml: "Important notice",
+          config: {},
+        },
+      };
+      const form = makeNormalizedForm({
+        fields,
+        fieldOrder: ["lbl1"],
+        blocks: [
+          {
+            type: "section",
+            id: "default",
+            title: undefined,
+            description: undefined,
+            questionIds: ["lbl1"],
+            order: 0,
+          },
+        ],
+      });
+
+      const result = sdk.renderHtml(form);
+      expect(result.html!.form).toContain("<p>Important notice</p>");
+    });
+  });
+
+  describe("grid field rendering", () => {
+    it("renders a grid with radio buttons by default", () => {
+      const fields: Record<string, NormalizedField> = {
+        g1: {
+          id: "g1",
+          type: "grid",
+          labelHtml: "Rate each item",
+          options: {
+            columns: [
+              ["c1", "Good"],
+              ["c2", "Bad"],
+            ],
+            rows: [
+              ["r1", "Service"],
+              ["r2", "Quality"],
+            ],
+          } as any,
+          config: {},
+        },
+      };
+      const form = makeNormalizedForm({
+        fields,
+        fieldOrder: ["g1"],
+        blocks: [
+          {
+            type: "section",
+            id: "default",
+            title: undefined,
+            description: undefined,
+            questionIds: ["g1"],
+            order: 0,
+          },
+        ],
+      });
+
+      const result = sdk.renderHtml(form);
+      expect(result.html!.form).toContain('class="grid-table"');
+      expect(result.html!.form).toContain("Rate each item");
+      expect(result.html!.form).toContain("<th>Good</th>");
+      expect(result.html!.form).toContain("<th>Bad</th>");
+      expect(result.html!.form).toContain("<td>Service</td>");
+      expect(result.html!.form).toContain("<td>Quality</td>");
+      expect(result.html!.form).toContain('type="radio"');
+      expect(result.html!.form).toContain('name="g1_r1"');
+      expect(result.html!.form).toContain('value="c1"');
+    });
+
+    it("renders checkboxes when allowMultiplePerRow is true", () => {
+      const fields: Record<string, NormalizedField> = {
+        g1: {
+          id: "g1",
+          type: "grid",
+          labelHtml: "Select all that apply",
+          options: {
+            columns: [["c1", "A"]],
+            rows: [["r1", "Row"]],
+          } as any,
+          config: { allowMultiplePerRow: true },
+        },
+      };
+      const form = makeNormalizedForm({
+        fields,
+        fieldOrder: ["g1"],
+        blocks: [
+          {
+            type: "section",
+            id: "default",
+            title: undefined,
+            description: undefined,
+            questionIds: ["g1"],
+            order: 0,
+          },
+        ],
+      });
+
+      const result = sdk.renderHtml(form);
+      expect(result.html!.form).toContain('type="checkbox"');
+    });
+  });
+
+  describe("intro block rendering", () => {
+    it("renders intro block with title", () => {
+      const form = makeNormalizedForm({
+        blocks: [{ type: "intro", title: "Welcome", description: undefined }],
+      });
+
+      const result = sdk.renderHtml(form);
+      expect(result.html!.form).toContain("form-intro");
+      expect(result.html!.form).toContain('class="form-name"');
+      expect(result.html!.form).toContain("Welcome");
+    });
+
+    it("renders intro block with description", () => {
+      const form = makeNormalizedForm({
+        blocks: [
+          { type: "intro", title: undefined, description: "Please fill out" },
+        ],
+      });
+
+      const result = sdk.renderHtml(form);
+      expect(result.html!.form).toContain('class="form-description"');
+      expect(result.html!.form).toContain("Please fill out");
+    });
+  });
+
+  describe("section block rendering", () => {
+    it("renders section with title and description", () => {
+      const fields: Record<string, NormalizedField> = {
+        q1: { id: "q1", type: "text", labelHtml: "Name", config: {} },
+      };
+      const form = makeNormalizedForm({
+        fields,
+        fieldOrder: ["q1"],
+        blocks: [
+          {
+            type: "section",
+            id: "s1",
+            title: "Personal Info",
+            description: "Tell us about yourself",
+            questionIds: ["q1"],
+            order: 0,
+          },
+        ],
+      });
+
+      const result = sdk.renderHtml(form);
+      expect(result.html!.form).toContain('class="section-title"');
+      expect(result.html!.form).toContain("Personal Info");
+      expect(result.html!.form).toContain('class="section-description"');
+      expect(result.html!.form).toContain("Tell us about yourself");
+    });
+  });
+
+  describe("unknown field type", () => {
+    it("renders empty string for unrecognized field types", () => {
+      const fields: Record<string, NormalizedField> = {
+        q1: {
+          id: "q1",
+          type: "unknown_type",
+          labelHtml: "Mystery",
+          config: {},
+        },
+      };
+      const form = makeNormalizedForm({
+        fields,
+        fieldOrder: ["q1"],
+        blocks: [
+          {
+            type: "section",
+            id: "default",
+            title: undefined,
+            description: undefined,
+            questionIds: ["q1"],
+            order: 0,
+          },
+        ],
+      });
+
+      const result = sdk.renderHtml(form);
+      // Should not contain the label since the field type is unknown
+      expect(result.html!.form).not.toContain("Mystery");
+    });
+  });
+
+  describe("mutates input form", () => {
+    it("adds html property to the input form object (mutates in place)", () => {
+      const form = makeNormalizedForm();
+      expect(form.html).toBeUndefined();
+      const result = sdk.renderHtml(form);
+      // renderHtml mutates the input and also returns it
+      expect(result).toBe(form);
+      expect(form.html).toBeDefined();
+    });
+  });
+});

--- a/packages/formstr-sdk/src/sdk/__tests__/submit.test.ts
+++ b/packages/formstr-sdk/src/sdk/__tests__/submit.test.ts
@@ -1,0 +1,278 @@
+import { FormstrSDK, createEphemeralSigner } from "../FormstrSDK";
+import type { NormalizedForm, NormalizedField } from "../types";
+
+// Mock the pool module to prevent actual relay connections
+jest.mock("../pool", () => ({
+  pool: {
+    publish: jest.fn().mockReturnValue([Promise.resolve("ok")]),
+  },
+}));
+
+import { pool } from "../pool";
+
+const sdk = new FormstrSDK();
+
+function makeForm(overrides: Partial<NormalizedForm> = {}): NormalizedForm {
+  return {
+    id: "test-form",
+    name: "Test Form",
+    pubkey: "abc123pubkey",
+    fields: {
+      q1: {
+        id: "q1",
+        type: "text",
+        labelHtml: "Your Name",
+        config: { required: true },
+      },
+      q2: {
+        id: "q2",
+        type: "option",
+        labelHtml: "Pick one",
+        options: [
+          { id: "opt1", labelHtml: "Yes" },
+          { id: "opt2", labelHtml: "No" },
+        ],
+        config: {},
+      },
+    },
+    fieldOrder: ["q1", "q2"],
+    relays: ["wss://relay.damus.io/", "wss://nos.lol"],
+    settings: {},
+    ...overrides,
+  };
+}
+
+describe("createEphemeralSigner", () => {
+  it("returns a function", () => {
+    const signer = createEphemeralSigner();
+    expect(typeof signer).toBe("function");
+  });
+
+  it("signs an event template and returns a valid event", async () => {
+    const signer = createEphemeralSigner();
+    const event = await signer({
+      kind: 1069,
+      content: "",
+      tags: [["a", "30168:pub:id"]],
+      created_at: Math.floor(Date.now() / 1000),
+    });
+
+    expect(event).toBeDefined();
+    expect(event.kind).toBe(1069);
+    expect(event.id).toBeDefined();
+    expect(event.sig).toBeDefined();
+    expect(event.pubkey).toBeDefined();
+    expect(typeof event.id).toBe("string");
+    expect(event.id.length).toBe(64); // hex SHA-256
+    expect(typeof event.sig).toBe("string");
+  });
+
+  it("produces different keys on each call", async () => {
+    const signer1 = createEphemeralSigner();
+    const signer2 = createEphemeralSigner();
+
+    const event1 = await signer1({
+      kind: 1,
+      content: "",
+      tags: [],
+      created_at: 1000,
+    });
+    const event2 = await signer2({
+      kind: 1,
+      content: "",
+      tags: [],
+      created_at: 1000,
+    });
+
+    expect(event1.pubkey).not.toBe(event2.pubkey);
+  });
+});
+
+describe("FormstrSDK.submit", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("creates a kind 1069 event with correct 'a' tag", async () => {
+    const form = makeForm();
+    const mockSigner = jest.fn().mockImplementation(async (event: any) => ({
+      ...event,
+      id: "mock-id",
+      sig: "mock-sig",
+      pubkey: "mock-pubkey",
+    }));
+
+    const result = await sdk.submit(form, { q1: "John" }, mockSigner);
+
+    // Check the signer was called with the right event shape
+    const signedEvent = mockSigner.mock.calls[0][0];
+    expect(signedEvent.kind).toBe(1069);
+    expect(signedEvent.content).toBe("");
+    expect(signedEvent.tags[0]).toEqual([
+      "a",
+      "30168:abc123pubkey:test-form",
+    ]);
+  });
+
+  it("creates response tags for each submitted value", async () => {
+    const form = makeForm();
+    const mockSigner = jest.fn().mockImplementation(async (event: any) => ({
+      ...event,
+      id: "mock-id",
+      sig: "mock-sig",
+      pubkey: "mock-pubkey",
+    }));
+
+    await sdk.submit(form, { q1: "Alice", q2: "opt1" }, mockSigner);
+
+    const signedEvent = mockSigner.mock.calls[0][0];
+    // tags[0] is the "a" tag, then response tags
+    expect(signedEvent.tags).toContainEqual([
+      "response",
+      "q1",
+      "Alice",
+      "{}",
+    ]);
+    expect(signedEvent.tags).toContainEqual([
+      "response",
+      "q2",
+      "opt1",
+      "{}",
+    ]);
+  });
+
+  it("joins array values with semicolon for multi-select", async () => {
+    const form = makeForm({
+      fields: {
+        q1: {
+          id: "q1",
+          type: "option",
+          labelHtml: "Choose many",
+          config: {},
+        },
+      },
+      fieldOrder: ["q1"],
+    });
+    const mockSigner = jest.fn().mockImplementation(async (event: any) => ({
+      ...event,
+      id: "mock-id",
+      sig: "mock-sig",
+      pubkey: "mock-pubkey",
+    }));
+
+    await sdk.submit(form, { q1: ["opt1", "opt2", "opt3"] }, mockSigner);
+
+    const signedEvent = mockSigner.mock.calls[0][0];
+    expect(signedEvent.tags).toContainEqual([
+      "response",
+      "q1",
+      "opt1;opt2;opt3",
+      "{}",
+    ]);
+  });
+
+  it("serializes grid values as JSON string", async () => {
+    const form = makeForm({
+      fields: {
+        g1: {
+          id: "g1",
+          type: "grid",
+          labelHtml: "Grid question",
+          config: {},
+        },
+      },
+      fieldOrder: ["g1"],
+    });
+    const mockSigner = jest.fn().mockImplementation(async (event: any) => ({
+      ...event,
+      id: "mock-id",
+      sig: "mock-sig",
+      pubkey: "mock-pubkey",
+    }));
+
+    const gridValue = { row1: "col1", row2: "col2" };
+    await sdk.submit(form, { g1: gridValue }, mockSigner);
+
+    const signedEvent = mockSigner.mock.calls[0][0];
+    expect(signedEvent.tags).toContainEqual([
+      "response",
+      "g1",
+      JSON.stringify(gridValue),
+      "{}",
+    ]);
+  });
+
+  it("passes through grid values that are already strings", async () => {
+    const form = makeForm({
+      fields: {
+        g1: {
+          id: "g1",
+          type: "grid",
+          labelHtml: "Grid question",
+          config: {},
+        },
+      },
+      fieldOrder: ["g1"],
+    });
+    const mockSigner = jest.fn().mockImplementation(async (event: any) => ({
+      ...event,
+      id: "mock-id",
+      sig: "mock-sig",
+      pubkey: "mock-pubkey",
+    }));
+
+    const gridStr = '{"row1":"col1"}';
+    await sdk.submit(form, { g1: gridStr }, mockSigner);
+
+    const signedEvent = mockSigner.mock.calls[0][0];
+    expect(signedEvent.tags).toContainEqual([
+      "response",
+      "g1",
+      gridStr,
+      "{}",
+    ]);
+  });
+
+  it("publishes the signed event to the form's relays", async () => {
+    const form = makeForm();
+    const mockSigner = jest.fn().mockImplementation(async (event: any) => ({
+      ...event,
+      id: "mock-id",
+      sig: "mock-sig",
+      pubkey: "mock-pubkey",
+    }));
+
+    await sdk.submit(form, { q1: "test" }, mockSigner);
+
+    expect(pool.publish).toHaveBeenCalledWith(
+      ["wss://relay.damus.io/", "wss://nos.lol"],
+      expect.objectContaining({ id: "mock-id" })
+    );
+  });
+
+  it("uses ephemeral signer when no signer is provided", async () => {
+    const form = makeForm();
+    const result = await sdk.submit(form, { q1: "test" });
+
+    // Should still succeed — the ephemeral signer creates a real event
+    expect(result).toBeDefined();
+    expect(result.kind).toBe(1069);
+    expect(result.id).toBeDefined();
+    expect(result.sig).toBeDefined();
+    expect(result.pubkey).toBeDefined();
+    expect(pool.publish).toHaveBeenCalled();
+  });
+
+  it("returns the signed event", async () => {
+    const form = makeForm();
+    const mockSigner = jest.fn().mockImplementation(async (event: any) => ({
+      ...event,
+      id: "signed-event-id",
+      sig: "signed-sig",
+      pubkey: "signed-pubkey",
+    }));
+
+    const result = await sdk.submit(form, { q1: "test" }, mockSigner);
+    expect(result.id).toBe("signed-event-id");
+  });
+});

--- a/packages/formstr-sdk/src/sdk/__tests__/validateResponse.test.ts
+++ b/packages/formstr-sdk/src/sdk/__tests__/validateResponse.test.ts
@@ -1,0 +1,244 @@
+import { validateResponse } from "../validateResponse";
+import type { NormalizedForm, NormalizedField, GridOptions } from "../types";
+
+/**
+ * Helper to create a minimal NormalizedForm for testing.
+ */
+function makeForm(
+  fields: Record<string, NormalizedField>,
+  fieldOrder: string[]
+): NormalizedForm {
+  return {
+    id: "test-form",
+    name: "Test Form",
+    pubkey: "abc123",
+    fields,
+    fieldOrder,
+    relays: [],
+    settings: {},
+  };
+}
+
+function textField(
+  id: string,
+  opts: { required?: boolean } = {}
+): NormalizedField {
+  return {
+    id,
+    type: "text",
+    labelHtml: `Question ${id}`,
+    config: { required: opts.required },
+  };
+}
+
+function optionField(
+  id: string,
+  opts: { required?: boolean } = {}
+): NormalizedField {
+  return {
+    id,
+    type: "option",
+    labelHtml: `Choice ${id}`,
+    options: [
+      { id: "opt1", labelHtml: "Option 1" },
+      { id: "opt2", labelHtml: "Option 2" },
+    ],
+    config: { required: opts.required },
+  };
+}
+
+function gridField(
+  id: string,
+  opts: {
+    required?: boolean;
+    rows?: Array<[string, string]>;
+    columns?: Array<[string, string]>;
+  } = {}
+): NormalizedField {
+  const gridOptions: GridOptions = {
+    rows: (opts.rows || [
+      ["row1", "Row 1"],
+      ["row2", "Row 2"],
+    ]) as Array<[string, string]>,
+    columns: (opts.columns || [
+      ["col1", "Column 1"],
+      ["col2", "Column 2"],
+    ]) as Array<[string, string]>,
+  };
+
+  return {
+    id,
+    type: "grid",
+    labelHtml: `Grid ${id}`,
+    options: gridOptions as any,
+    config: { required: opts.required },
+  };
+}
+
+describe("validateResponse", () => {
+  describe("non-required fields", () => {
+    it("passes when no values are provided for optional fields", () => {
+      const form = makeForm(
+        { q1: textField("q1"), q2: optionField("q2") },
+        ["q1", "q2"]
+      );
+      expect(validateResponse(form, {})).toBe(true);
+    });
+
+    it("passes when values are provided for optional fields", () => {
+      const form = makeForm(
+        { q1: textField("q1"), q2: optionField("q2") },
+        ["q1", "q2"]
+      );
+      expect(
+        validateResponse(form, { q1: "answer", q2: "opt1" })
+      ).toBe(true);
+    });
+  });
+
+  describe("required text fields", () => {
+    it("throws when a required text field is missing", () => {
+      const form = makeForm(
+        { q1: textField("q1", { required: true }) },
+        ["q1"]
+      );
+      expect(() => validateResponse(form, {})).toThrow(
+        "Required field missing: q1"
+      );
+    });
+
+    it("throws when a required text field is empty string", () => {
+      const form = makeForm(
+        { q1: textField("q1", { required: true }) },
+        ["q1"]
+      );
+      expect(() => validateResponse(form, { q1: "" })).toThrow(
+        "Required field missing: q1"
+      );
+    });
+
+    it("passes when a required text field is provided", () => {
+      const form = makeForm(
+        { q1: textField("q1", { required: true }) },
+        ["q1"]
+      );
+      expect(validateResponse(form, { q1: "answer" })).toBe(true);
+    });
+  });
+
+  describe("required option fields", () => {
+    it("throws when a required option field is missing", () => {
+      const form = makeForm(
+        { q1: optionField("q1", { required: true }) },
+        ["q1"]
+      );
+      expect(() => validateResponse(form, {})).toThrow(
+        "Required field missing: q1"
+      );
+    });
+
+    it("passes when a required option field is provided", () => {
+      const form = makeForm(
+        { q1: optionField("q1", { required: true }) },
+        ["q1"]
+      );
+      expect(validateResponse(form, { q1: "opt1" })).toBe(true);
+    });
+  });
+
+  describe("mixed required and optional fields", () => {
+    it("throws when any required field is missing", () => {
+      const form = makeForm(
+        {
+          q1: textField("q1", { required: true }),
+          q2: textField("q2"),
+          q3: optionField("q3", { required: true }),
+        },
+        ["q1", "q2", "q3"]
+      );
+      // q1 is provided, q3 is required but missing
+      expect(() =>
+        validateResponse(form, { q1: "answer", q2: "optional" })
+      ).toThrow("Required field missing: q3");
+    });
+
+    it("passes when all required fields are provided and optional are skipped", () => {
+      const form = makeForm(
+        {
+          q1: textField("q1", { required: true }),
+          q2: textField("q2"),
+          q3: optionField("q3", { required: true }),
+        },
+        ["q1", "q2", "q3"]
+      );
+      expect(
+        validateResponse(form, { q1: "answer", q3: "opt1" })
+      ).toBe(true);
+    });
+  });
+
+  describe("grid field validation", () => {
+    it("throws when a required grid field has missing rows", () => {
+      const form = makeForm(
+        { g1: gridField("g1", { required: true }) },
+        ["g1"]
+      );
+      // Provide only row1, missing row2
+      expect(() =>
+        validateResponse(form, { g1: JSON.stringify({ row1: "col1" }) })
+      ).toThrow(/Required grid row missing/);
+    });
+
+    it("throws when a required grid row has empty string value", () => {
+      const form = makeForm(
+        { g1: gridField("g1", { required: true }) },
+        ["g1"]
+      );
+      expect(() =>
+        validateResponse(form, {
+          g1: JSON.stringify({ row1: "col1", row2: "" }),
+        })
+      ).toThrow(/Required grid row missing/);
+    });
+
+    it("passes when all required grid rows are filled", () => {
+      const form = makeForm(
+        { g1: gridField("g1", { required: true }) },
+        ["g1"]
+      );
+      expect(
+        validateResponse(form, {
+          g1: JSON.stringify({ row1: "col1", row2: "col2" }),
+        })
+      ).toBe(true);
+    });
+
+    it("passes when a non-required grid field is missing", () => {
+      const form = makeForm(
+        { g1: gridField("g1", { required: false }) },
+        ["g1"]
+      );
+      expect(validateResponse(form, {})).toBe(true);
+    });
+
+    it("handles grid values passed as objects (not strings)", () => {
+      const form = makeForm(
+        { g1: gridField("g1", { required: true }) },
+        ["g1"]
+      );
+      // validateResponse also handles non-string values via typeof check
+      expect(
+        validateResponse(form, {
+          g1: { row1: "col1", row2: "col2" } as any,
+        })
+      ).toBe(true);
+    });
+  });
+
+  describe("empty form", () => {
+    it("passes validation with no fields and no values", () => {
+      const form = makeForm({}, []);
+      expect(validateResponse(form, {})).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds the **unit test suite** for `@formstr/sdk`. The SDK previously had Jest configured but lacked **test files**. This PR introduces **104 tests across 7 test files** covering every testable module in the package.

Closes #437 

## What's Tested

| Test File | Tests | Module | What's covered |
|-----------|-------|--------|---------------|
| `nkeys.test.ts` | 12 | `utils/nkeys.ts` | `encodeNKeys`/`decodeNKeys` round-trips, determinism, unicode support, error handling for invalid bech32 |
| `helper.test.ts` | 17 | `utils/helper.ts` | `stripHtml` (undefined, empty, nested tags, attributes, XSS, whitespace), `getOrderedFieldIds` (section ordering) |
| `validateResponse.test.ts` | 15 | `validateResponse.ts` | Required/optional text + option fields, grid row validation (missing/empty), object vs string values, empty form |
| `normalizeForm.test.ts` | 25 | `FormstrSDK.ts` | Metadata extraction (`d`, `name`, `pubkey`, `relay` tags), settings parsing, field normalization (text/option/label with configs), intro + section block generation, complete form round-trips |
| `renderHtml.test.ts` | 13 | `FormstrSDK.ts` | HTML structure (`<form>` wrapper, submit button), text/option/label/grid field rendering, grid checkbox vs radio, intro + section blocks, unknown field types |
| `submit.test.ts` | 11 | `FormstrSDK.ts` | `createEphemeralSigner` (key generation, signing), kind:1069 event construction, `a` tag format, response tags, multi-select semicolon joining, grid JSON serialization, relay publishing |
| `fetchFormTemplate.test.ts` | 11 | `utils/fetchFormTemplate.ts` | `getDefaultRelays`, public form tag extraction, pubkey tag injection, missing event error, encrypted form without keys error, correct filter construction, naddr relay resolution, default relay fallback |

## Infrastructure Change

**`jest.config.js`** — Added `moduleNameMapper` to strip `.js` extensions from relative imports:

```js
moduleNameMapper: {
  "^(\\.\\.?/.*)\\.js$": "$1",
},
```

**Why:** The SDK source uses ESM-style `.js` extensions in TypeScript imports (e.g., `import { pool } from "./pool.js"`). This is correct for the Rollup build output, but Jest with `ts-jest` resolves `.ts` files directly and can't find the `.js` variants. The mapper transparently strips the extension.

## Design Decisions

1. **No source code changes** — This is a test-only PR. Zero modifications to any `.ts` file in `src/sdk/` outside of `__tests__/`.
2. **Mocked relay connections** — `SimplePool` and the pool singleton are mocked via `jest.mock()` so tests never open WebSocket connections.
3. **Tests match actual behavior** — e.g., `stripHtml` removes tags without inserting whitespace (`"Line1<br/>Line2"` → `"Line1Line2"`), so tests assert the actual behavior, not idealized behavior.
4. **Ephemeral signer tested with real crypto** — `createEphemeralSigner` tests use actual `nostr-tools` signing (not mocked) to ensure real Schnorr signatures are produced.

## How to Verify

```bash
cd packages/formstr-sdk
npx jest --verbose --forceExit --no-cache
```

Expected output:
```
Test Suites: 7 passed, 7 total
Tests:       104 passed, 104 total
```

## Checklist

- [x] All 104 tests pass
- [x] No source code changes (test-only)
- [x] All relay interactions mocked
- [x] Covers edge cases (empty forms, missing tags, unicode, invalid inputs)
- [x] Follows existing project structure and conventions
- [x] `jest.config.js` change is minimal and well-documented
