### PR TITLE
Refactor form link generation into a single helper surface

### DIFF
--- a/packages/formstr-app/src/containers/CreateFormNew/components/FormDetails/EmbedWithSDKTab.tsx
+++ b/packages/formstr-app/src/containers/CreateFormNew/components/FormDetails/EmbedWithSDKTab.tsx
@@ -1,6 +1,6 @@
 import { Typography } from "antd";
 import { CopyButton } from "../../../../components/CopyButton";
-import { makeFormNAddr } from "../../../../utils/utility";
+import { makeFormNAddr } from "../../../../utils/formLinks";
 
 const { Text } = Typography;
 

--- a/packages/formstr-app/src/containers/CreateFormNew/components/FormDetails/index.tsx
+++ b/packages/formstr-app/src/containers/CreateFormNew/components/FormDetails/index.tsx
@@ -1,4 +1,4 @@
-import { Modal, Card, Divider, Typography, Button, Alert } from "antd";
+import { Modal, Card, Divider } from "antd";
 import { useEffect, useState } from "react";
 import FormDetailsStyle from "./FormDetails.style";
 import { useProfileContext } from "../../../../hooks/useProfileContext";
@@ -6,14 +6,14 @@ import {
   constructFormUrl,
   constructNewResponseUrl,
   editPath,
-} from "../../../../utils/formUtils";
+  makeFormNAddr,
+} from "../../../../utils/formLinks";
 import { ShareTab } from "./ShareTab";
 import { EmbedTab } from "./EmbedTab";
 import { SaveStatus } from "./SaveStatus";
 import { saveToDevice } from "./utils/saveHelpers";
 import { CustomSlugForm } from "./payments/customSlugForm";
 import { useNavigate } from "react-router-dom";
-import { makeFormNAddr } from "../../../../utils/utility";
 import { useMyForms } from "../../../../provider/MyFormsProvider";
 import { EmbedWithSDKTab } from "./EmbedWithSDKTab";
 

--- a/packages/formstr-app/src/containers/Dashboard/FormCards/Drafts.tsx
+++ b/packages/formstr-app/src/containers/Dashboard/FormCards/Drafts.tsx
@@ -4,17 +4,7 @@ import { Tag } from "../../../nostr/types";
 import { DeleteOutlined } from "@ant-design/icons";
 import { deleteDraft } from "../../../utils/utility";
 import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
-
-export function constructDraftUrl(
-  draft: { formSpec: unknown; tempId: string },
-  host: string,
-) {
-  if (!draft) return;
-  let draftHash = window.btoa(encodeURIComponent(JSON.stringify(draft)));
-  draftHash = window.encodeURIComponent(draftHash);
-  return `${host}/drafts/${draftHash}`;
-}
+import { constructDraftUrl } from "../../../utils/formLinks";
 
 export const Drafts = () => {
   type Draft = { formSpec: Tag[]; tempId: string };

--- a/packages/formstr-app/src/containers/Dashboard/FormCards/FormEventCard.tsx
+++ b/packages/formstr-app/src/containers/Dashboard/FormCards/FormEventCard.tsx
@@ -2,18 +2,15 @@ import { Button, Card, Divider, Dropdown, MenuProps } from "antd";
 import { Event } from "nostr-tools";
 import { useNavigate } from "react-router-dom";
 import DeleteFormTrigger from "./DeleteForm";
-import {
-  downloadHTMLToDevice,
-  makeFormNAddr,
-  naddrUrl,
-  makeTag,
-} from "../../../utils/utility";
+import { downloadHTMLToDevice, makeTag } from "../../../utils/utility";
 import {
   editPath,
-  getDecryptedForm,
-  getFormData,
+  makeFormNAddr,
+  naddrUrl,
   responsePath,
-} from "../../../utils/formUtils";
+  constructDraftUrl,
+} from "../../../utils/formLinks";
+import { getDecryptedForm, getFormData } from "../../../utils/formUtils";
 import {
   DownloadOutlined,
   EditOutlined,
@@ -22,7 +19,6 @@ import {
   InfoCircleOutlined,
 } from "@ant-design/icons";
 import { useEffect, useState } from "react";
-import { constructDraftUrl } from "./Drafts";
 import { FormDetails } from "../../CreateFormNew/components/FormDetails";
 import SafeMarkdown from "../../../components/SafeMarkdown";
 import { IFormSettings } from "../../CreateFormNew/components/FormSettings/types";
@@ -39,7 +35,6 @@ interface FormEventCardProps {
 export const FormEventCard: React.FC<FormEventCardProps> = ({
   event,
   onDeleted,
-  relay,
   secretKey,
   viewKey,
   shortLink,

--- a/packages/formstr-app/src/containers/Dashboard/FormCards/LocalFormCard.tsx
+++ b/packages/formstr-app/src/containers/Dashboard/FormCards/LocalFormCard.tsx
@@ -1,9 +1,13 @@
-import { Button, Card, Typography, Dropdown, MenuProps } from "antd";
+import { Button, Card, Dropdown, MenuProps } from "antd";
 import { ILocalForm } from "../../CreateFormNew/providers/FormBuilder/typeDefs";
 import { useNavigate } from "react-router-dom";
 import DeleteFormTrigger from "./DeleteForm";
-import { makeFormNAddr, naddrUrl } from "../../../utils/utility";
-import { editPath, responsePath } from "../../../utils/formUtils";
+import {
+  editPath,
+  makeFormNAddr,
+  naddrUrl,
+  responsePath,
+} from "../../../utils/formLinks";
 import { EditOutlined, MoreOutlined } from "@ant-design/icons";
 import SafeMarkdown from "../../../components/SafeMarkdown";
 
@@ -12,7 +16,6 @@ interface LocalFormCardProps {
   onDeleted: () => void;
 }
 
-const { Text } = Typography;
 export const LocalFormCard: React.FC<LocalFormCardProps> = ({
   form,
   onDeleted,
@@ -24,9 +27,9 @@ export const LocalFormCard: React.FC<LocalFormCardProps> = ({
         makeFormNAddr(
           form.publicKey,
           form.formId,
-          form.relays && form.relays.length !== 0 ? form.relays : [form.relay]
+          form.relays && form.relays.length !== 0 ? form.relays : [form.relay],
         ),
-        form.viewKey
+        form.viewKey,
       )
     : `/response/${form.privateKey}`;
   let formUrl =
@@ -45,10 +48,10 @@ export const LocalFormCard: React.FC<LocalFormCardProps> = ({
             makeFormNAddr(
               form.publicKey,
               form.formId,
-              form.relays?.length ? form.relays : undefined
+              form.relays?.length ? form.relays : undefined,
             ),
-            form.viewKey
-          )
+            form.viewKey,
+          ),
         ),
     },
   ];

--- a/packages/formstr-app/src/containers/PublicForms/PublicFormCard.tsx
+++ b/packages/formstr-app/src/containers/PublicForms/PublicFormCard.tsx
@@ -1,5 +1,5 @@
 import { Card, Divider, Typography } from "antd";
-import { naddrUrl } from "../../utils/utility";
+import { naddrUrl } from "../../utils/formLinks";
 import { useNavigate } from "react-router-dom";
 import { getDefaultRelays } from "../../nostr/common";
 import { Event } from "nostr-tools";

--- a/packages/formstr-app/src/setupTests.js
+++ b/packages/formstr-app/src/setupTests.js
@@ -3,3 +3,7 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import "@testing-library/jest-dom";
+import { TextDecoder, TextEncoder } from "util";
+
+globalThis.TextEncoder = TextEncoder;
+globalThis.TextDecoder = TextDecoder;

--- a/packages/formstr-app/src/utils/formLinks.test.ts
+++ b/packages/formstr-app/src/utils/formLinks.test.ts
@@ -1,0 +1,58 @@
+import {
+  constructDraftUrl,
+  constructFormUrl,
+  editPath,
+  makeFormNAddr,
+  responsePath,
+} from "./formLinks";
+import { encodeNKeys } from "./nkeys";
+
+describe("formLinks", () => {
+  test("constructDraftUrl builds a draft link from the provided host", () => {
+    const draft = {
+      formSpec: [["name", "Draft form"]],
+      tempId: "abc123",
+    };
+
+    expect(constructDraftUrl(draft, "https://formstr.app")).toMatch(
+      /^https:\/\/formstr\.app\/drafts\//,
+    );
+  });
+
+  test("constructFormUrl preserves preview query param behavior", () => {
+    const url = constructFormUrl(
+      "f".repeat(64),
+      "form123",
+      ["wss://relay.example.com"],
+      "view-secret",
+      false,
+      "https://formstr.app",
+    );
+
+    expect(url).toContain("/f/");
+    expect(url).toContain("?viewKey=view-secret");
+  });
+
+  test("editPath encodes secrets in the hash when preview is disabled", () => {
+    const naddr = makeFormNAddr("f".repeat(64), "form123", [
+      "wss://relay.example.com",
+    ]);
+
+    expect(editPath("secret-key", naddr, "view-secret", true)).toBe(
+      `/edit/${naddr}#${encodeNKeys({
+        viewKey: "view-secret",
+        secretKey: "secret-key",
+      })}`,
+    );
+  });
+
+  test("responsePath keeps the legacy preview-compatible format when enabled", () => {
+    const naddr = makeFormNAddr("f".repeat(64), "form123", [
+      "wss://relay.example.com",
+    ]);
+
+    expect(responsePath("secret-key", naddr, "view-secret", false)).toBe(
+      `/s/${naddr}?viewKey=view-secret#secret-key`,
+    );
+  });
+});

--- a/packages/formstr-app/src/utils/formLinks.ts
+++ b/packages/formstr-app/src/utils/formLinks.ts
@@ -1,0 +1,163 @@
+import { hexToBytes } from "@noble/hashes/utils";
+import { getPublicKey, nip19 } from "nostr-tools";
+import { encodeNKeys } from "./nkeys";
+
+const DEFAULT_FORM_RELAYS = ["wss://relay.damus.io"];
+
+export type DraftLinkPayload = {
+  formSpec: unknown;
+  tempId: string;
+};
+
+const getRelayList = (relaysEncode?: string[]) => {
+  return relaysEncode && relaysEncode.length !== 0
+    ? relaysEncode
+    : DEFAULT_FORM_RELAYS;
+};
+
+const appendQueryParams = (
+  basePath: string,
+  params: Record<string, string | null | undefined>,
+) => {
+  const searchParams = new URLSearchParams();
+  Object.entries(params).forEach(([key, value]) => {
+    if (value) {
+      searchParams.set(key, value);
+    }
+  });
+
+  const query = searchParams.toString();
+  return query ? `${basePath}?${query}` : basePath;
+};
+
+const appendHash = (basePath: string, hash?: string) => {
+  return hash ? `${basePath}#${hash}` : basePath;
+};
+
+const withOrigin = (path: string, host = window.location.origin) => {
+  return `${host}${path}`;
+};
+
+const getDraftPath = (draft: DraftLinkPayload) => {
+  let draftHash = window.btoa(encodeURIComponent(JSON.stringify(draft)));
+  draftHash = window.encodeURIComponent(draftHash);
+  return `/drafts/${draftHash}`;
+};
+
+export const makeFormNAddr = (
+  publicKey: string,
+  formId: string,
+  relaysEncode?: string[],
+) => {
+  return nip19.naddrEncode({
+    pubkey: publicKey,
+    identifier: formId,
+    relays: getRelayList(relaysEncode),
+    kind: 30168,
+  });
+};
+
+/**
+ * `disablePreview` preserves the newer link contract where secrets live in the
+ * hash fragment instead of query params or server-visible routes.
+ */
+export const naddrUrl = (
+  publicKey: string,
+  formId: string,
+  relaysEncode?: string[],
+  viewKey?: string | null,
+  disablePreview = false,
+) => {
+  const basePath = `/f/${makeFormNAddr(publicKey, formId, relaysEncode)}`;
+
+  if (!disablePreview) {
+    return appendQueryParams(basePath, { viewKey });
+  }
+
+  return appendHash(basePath, viewKey ? encodeNKeys({ viewKey }) : undefined);
+};
+
+export const constructFormUrl = (
+  pubkey: string,
+  formId: string,
+  relays: string[],
+  viewKey?: string | null,
+  disablePreview = false,
+  host = window.location.origin,
+) => {
+  return withOrigin(
+    naddrUrl(pubkey, formId, relays, viewKey, disablePreview),
+    host,
+  );
+};
+
+export const editPath = (
+  formSecret: string,
+  naddr: string,
+  viewKey?: string | null,
+  disablePreview = true,
+) => {
+  const basePath = `/edit/${naddr}`;
+
+  if (!disablePreview) {
+    return appendHash(appendQueryParams(basePath, { viewKey }), formSecret);
+  }
+
+  return appendHash(
+    basePath,
+    encodeNKeys({
+      ...(viewKey ? { viewKey } : {}),
+      secretKey: formSecret,
+    }),
+  );
+};
+
+export const responsePath = (
+  secretKey: string,
+  naddr: string,
+  viewKey?: string | null,
+  disablePreview = false,
+) => {
+  const basePath = `/s/${naddr}`;
+
+  if (!disablePreview) {
+    return appendHash(appendQueryParams(basePath, { viewKey }), secretKey);
+  }
+
+  return appendHash(
+    basePath,
+    encodeNKeys({
+      ...(viewKey ? { viewKey } : {}),
+      secretKey,
+    }),
+  );
+};
+
+export const constructNewResponseUrl = (
+  secretKey: string,
+  formId: string,
+  relays?: string[],
+  viewKey?: string,
+  disablePreview = false,
+  host = window.location.origin,
+) => {
+  const naddr = makeFormNAddr(
+    getPublicKey(hexToBytes(secretKey)),
+    formId,
+    relays,
+  );
+  return withOrigin(
+    responsePath(secretKey, naddr, viewKey, disablePreview),
+    host,
+  );
+};
+
+export function constructDraftUrl(
+  draft: DraftLinkPayload | null,
+  host = window.location.origin,
+) {
+  if (!draft) {
+    return;
+  }
+  return withOrigin(getDraftPath(draft), host);
+}

--- a/packages/formstr-app/src/utils/formUtils.ts
+++ b/packages/formstr-app/src/utils/formUtils.ts
@@ -1,22 +1,20 @@
 import { FormTemplate } from "../templates";
-import { makeFormNAddr, makeTag } from "./utility";
-import {
-  nip44,
-  Event,
-  UnsignedEvent,
-  nip19,
-  getPublicKey,
-} from "nostr-tools";
+import { makeTag } from "./utility";
+import { nip44, Event, UnsignedEvent, nip19 } from "nostr-tools";
 import { bytesToHex, hexToBytes } from "@noble/hashes/utils";
 import { sha256 } from "@noble/hashes/sha256";
-import { naddrUrl } from "./utility";
 import { AddressPointer } from "nostr-tools/nip19";
 import { fetchFormTemplate } from "../nostr/fetchFormTemplate";
 import { signerManager } from "../signer";
-import { encodeNKeys } from "./nkeys";
 import { getDefaultRelays } from "../nostr/common";
 import { Tag } from "../nostr/types";
 import { pool } from "../pool";
+import {
+  constructFormUrl as buildFormUrl,
+  constructNewResponseUrl as buildResponseUrl,
+  editPath as buildEditPath,
+  responsePath as buildResponsePath,
+} from "./formLinks";
 
 export const createFormSpecFromTemplate = (
   template: FormTemplate,
@@ -141,9 +139,7 @@ export const constructFormUrl = (
   viewKey?: string,
   disablePreview: boolean = false,
 ) => {
-  const naddr = naddrUrl(pubkey, formId, relays, viewKey, disablePreview);
-  const baseUrl = `${window.location.origin}${naddr}`;
-  return baseUrl;
+  return buildFormUrl(pubkey, formId, relays, viewKey, disablePreview);
 };
 
 export const editPath = (
@@ -152,22 +148,7 @@ export const editPath = (
   viewKey?: string | null,
   disablePreview = true,
 ) => {
-  const base = `/edit/${naddr}`;
-
-  if (!disablePreview) {
-    const params = new URLSearchParams();
-    if (viewKey) params.set("viewKey", viewKey);
-    const query = params.toString() ? `?${params}` : "";
-    return `${base}${query}#${formSecret}`;
-  }
-
-  // NEW: private links
-  const nkey = encodeNKeys({
-    ...(viewKey && { viewKey }),
-    secretKey: formSecret,
-  });
-
-  return `${base}#${nkey}`;
+  return buildEditPath(formSecret, naddr, viewKey, disablePreview);
 };
 
 export const responsePath = (
@@ -176,22 +157,7 @@ export const responsePath = (
   viewKey?: string | null,
   disablePreview = false, // true -> server-visible
 ) => {
-  const base = `/s/${naddr}`;
-
-  if (!disablePreview) {
-    const params = new URLSearchParams();
-    if (viewKey) params.set("viewKey", viewKey);
-    const query = params.toString() ? `?${params.toString()}` : "";
-    return `${base}${query}#${secretKey}`;
-  }
-
-  // Private: encode into nkeys
-  const nkey = encodeNKeys({
-    ...(viewKey ? { viewKey } : {}),
-    secretKey,
-  });
-
-  return `${base}#${nkey}`;
+  return buildResponsePath(secretKey, naddr, viewKey, disablePreview);
 };
 
 export const constructNewResponseUrl = (
@@ -201,14 +167,7 @@ export const constructNewResponseUrl = (
   viewKey?: string,
   disablePreview: boolean = false,
 ) => {
-  const baseUrl = `${window.location.origin}`;
-  const responsePart = responsePath(
-    secretKey,
-    makeFormNAddr(getPublicKey(hexToBytes(secretKey)), formId, relays),
-    viewKey,
-    disablePreview,
-  );
-  return `${baseUrl}${responsePart}`;
+  return buildResponseUrl(secretKey, formId, relays, viewKey, disablePreview);
 };
 
 export const getFormData = async (naddr: string) => {
@@ -217,9 +176,14 @@ export const getFormData = async (naddr: string) => {
   const formId = decodedData?.identifier;
   const relays = decodedData?.relays;
   return new Promise((resolve) => {
-    fetchFormTemplate(pubKey, formId, (event: Event) => {
-      resolve(event);
-    }, relays);
+    fetchFormTemplate(
+      pubKey,
+      formId,
+      (event: Event) => {
+        resolve(event);
+      },
+      relays,
+    );
   });
 };
 

--- a/packages/formstr-app/src/utils/utility.ts
+++ b/packages/formstr-app/src/utils/utility.ts
@@ -1,7 +1,10 @@
 import { DEVICE_TYPE, DEVICE_WIDTH } from "../constants/index";
 import { getItem, LOCAL_STORAGE_KEYS, setItem } from "./localStorage";
-import { nip19 } from "nostr-tools";
-import { encodeNKeys } from "./nkeys";
+import {
+  constructDraftUrl as buildDraftUrl,
+  makeFormNAddr as buildFormNAddr,
+  naddrUrl as buildNaddrUrl,
+} from "./formLinks";
 
 export function makeTag(length: number) {
   let result = "";
@@ -36,12 +39,7 @@ export const makeFormNAddr = (
   formId: string,
   relaysEncode?: string[],
 ) => {
-  return nip19.naddrEncode({
-    pubkey: publicKey,
-    identifier: formId,
-    relays: relaysEncode || ["wss://relay.damus.io"],
-    kind: 30168,
-  });
+  return buildFormNAddr(publicKey, formId, relaysEncode);
 };
 
 export const naddrUrl = (
@@ -51,35 +49,19 @@ export const naddrUrl = (
   viewKey?: string | null,
   disablePreview = false,
 ) => {
-  const base = `/f/${makeFormNAddr(
+  return buildNaddrUrl(
     publicKey,
     formId,
-    relaysEncode || ["wss://relay.damus.io"],
-  )}`;
-
-  // OLD behavior
-  if (!disablePreview) {
-    return viewKey ? `${base}?viewKey=${viewKey}` : base;
-  }
-
-  // NEW behavior: encode hash
-  if (!viewKey) return base;
-
-  const nkey = encodeNKeys({ viewKey });
-  return `${base}#${nkey}`;
+    relaysEncode,
+    viewKey,
+    disablePreview,
+  );
 };
 
 export function constructDraftUrl(
   draft: { formSpec: unknown; tempId: string } | null,
 ) {
-  if (!draft) {
-    return;
-  }
-  let draftHash = window.btoa(encodeURIComponent(JSON.stringify(draft)));
-  draftHash = window.encodeURIComponent(draftHash);
-  const hostname = window.location.host;
-
-  return `http://${hostname}/drafts/${draftHash}`;
+  return buildDraftUrl(draft);
 }
 
 export function constructResponseUrl(privateKey: string | null) {


### PR DESCRIPTION
## Summary

This PR consolidates the active form link generation logic into a single helper module for the web app.

It introduces `src/utils/formLinks.ts` as the canonical place for generating:

- form `naddr`s
- public form URLs
- edit links
- response links
- draft links

It also updates the main call sites to use the new helper surface, while keeping compatibility wrappers in existing utility modules so the change stays narrow and low-risk.

## Why

Form link generation was previously split across multiple places:

- `src/utils/utility.ts`
- `src/utils/formUtils.ts`
- `src/containers/Dashboard/FormCards/Drafts.tsx`

That made the link contract harder to follow and easier to drift, especially around:

- `naddr` generation
- `viewKey` handling
- `secretKey` placement in hash/query
- draft URL encoding

This PR reduces that duplication and makes the current link behavior easier to maintain.

## Changes

- added `src/utils/formLinks.ts`
- added focused tests in `src/utils/formLinks.test.ts`
- updated the main form link consumers to use the centralized helper
- kept thin wrappers in older utility modules to avoid a broad refactor
- added `TextEncoder` / `TextDecoder` setup in `src/setupTests.js` for `nostr-tools` in Jest

## Validation

Ran:

- `yarn install`
- `yarn workspace @formstr/web-app test --watch=false src/utils/formLinks.test.ts`

Also checked:

- `git diff --check`

## Scope notes

This PR intentionally does not try to refactor every historical or deprecated link helper pattern in the repo.

The goal here is to centralize the active link contract used by the current app flows while keeping behavior changes minimal and the patch easy to review.
