### PR TITLE
login_error_when we click_on_cross_button_showing_to_user_in_console

### DIFF
--- a/packages/formstr-app/src/provider/ProfileProvider.tsx
+++ b/packages/formstr-app/src/provider/ProfileProvider.tsx
@@ -11,7 +11,7 @@ import { Modal } from "antd";
 import { Filter } from "nostr-tools";
 import { pool } from "../pool";
 import { getDefaultRelays } from "../nostr/common";
-import { signerManager } from "../signer";
+import { isLoginCancelledError, LoginCancelledError, signerManager } from "../signer";
 import LoginModal from "../components/LoginModal";
 
 interface ProfileProviderProps {
@@ -68,7 +68,7 @@ export const ProfileProvider: FC<ProfileProviderProps> = ({ children }) => {
         // Pass a function to handle modal close without login
         const handleLoginCancel = () => {
           setShowLoginModal(false);
-          reject(new Error("Login cancelled")); // Unblock getSigner with error
+          reject(new LoginCancelledError()); // Unblock getSigner with a cancellable error
         };
 
         setLoginHandler(() => ({
@@ -78,7 +78,7 @@ export const ProfileProvider: FC<ProfileProviderProps> = ({ children }) => {
       });
     });
     const unsubscribe = signerManager.onChange(async () => {
-      const signer = await signerManager.getSigner();
+      const signer = signerManager.getSignerIfAvailable();
       if (signer) {
         try {
           const pk = await signer.getPublicKey();
@@ -112,10 +112,18 @@ export const ProfileProvider: FC<ProfileProviderProps> = ({ children }) => {
   };
 
   const requestPubkey = async () => {
-    let publicKey = await (await signerManager.getSigner()).getPublicKey();
-    setPubkey(publicKey);
-    setItem(LOCAL_STORAGE_KEYS.PROFILE, { pubkey: publicKey });
-    return publicKey;
+    try {
+      const publicKey = await (await signerManager.getSigner()).getPublicKey();
+      setPubkey(publicKey);
+      setItem(LOCAL_STORAGE_KEYS.PROFILE, { pubkey: publicKey });
+      return publicKey;
+    } catch (error) {
+      if (isLoginCancelledError(error)) {
+        return undefined;
+      }
+
+      throw error;
+    }
   };
 
   return (

--- a/packages/formstr-app/src/signer/index.ts
+++ b/packages/formstr-app/src/signer/index.ts
@@ -19,6 +19,17 @@ import * as nip49 from "nostr-tools/nip49";
 import { bytesToHex } from "@noble/hashes/utils";
 import { publishKind0 } from "../nostr/common";
 
+export class LoginCancelledError extends Error {
+  constructor() {
+    super("Login cancelled");
+    this.name = "LoginCancelledError";
+  }
+}
+
+export const isLoginCancelledError = (error: unknown) =>
+  error instanceof LoginCancelledError ||
+  (error instanceof Error && error.message === "Login cancelled");
+
 class Signer {
   private signer: NostrSigner | null = null;
   private onChangeCallbacks: Set<() => void> = new Set();


### PR DESCRIPTION
issue #451 

I have updated the code so closing the login modal is treated as a normal cancel action, not a real app error. Now the login flow catches that cancel case and exits quietly instead of throwing an uncaught runtime error. 

I have also tested no error was coming in console now 