### PR TITLE
feat: add ability to zap self signed responses

### DIFF
--- a/packages/formstr-app/src/containers/ResponsesNew/components/ResponseDetailModal.tsx
+++ b/packages/formstr-app/src/containers/ResponsesNew/components/ResponseDetailModal.tsx
@@ -8,6 +8,8 @@ import {
   DisplayableAnswerDetail,
 } from "../../../utils/ResponseUtils";
 import { FormRenderer } from "../../FormFillerNew/FormRenderer";
+import { ResponderProfile, ZapTotal, hasLightningAddress } from "../../../nostr/zaps";
+import { ZapButton } from "./ZapButton";
 
 const { Text } = Typography;
 
@@ -24,6 +26,11 @@ interface ResponseDetailModalProps {
   responseMetadataEvent: Event | null;
   formstrBranding?: boolean;
   editKey?: string | null;
+  formEvent?: Event;
+  recipientProfileEvent?: Event;
+  profile?: ResponderProfile;
+  zapTotal?: ZapTotal;
+  onZapInitiated?: () => void;
 }
 export const ResponseDetailModal: React.FC<ResponseDetailModalProps> = ({
   isVisible,
@@ -33,6 +40,11 @@ export const ResponseDetailModal: React.FC<ResponseDetailModalProps> = ({
   responseMetadataEvent,
   formstrBranding,
   editKey,
+  formEvent,
+  recipientProfileEvent,
+  profile,
+  zapTotal,
+  onZapInitiated,
 }) => {
   const [metaData, setMetaData] = useState<{
     author?: string;
@@ -92,6 +104,16 @@ export const ResponseDetailModal: React.FC<ResponseDetailModalProps> = ({
           <Text type="secondary" style={{ fontSize: "0.8em" }}>
             Submitted: {metaData.timestamp || "N/A"}
           </Text>
+          {hasLightningAddress(profile) && responseMetadataEvent && formEvent && (
+            <ZapButton
+              recipientProfileEvent={recipientProfileEvent}
+              profile={profile}
+              responseEvent={responseMetadataEvent}
+              formEvent={formEvent}
+              zapTotal={zapTotal}
+              onZapInitiated={onZapInitiated}
+            />
+          )}
         </Space>
       }
       open={isVisible}

--- a/packages/formstr-app/src/containers/ResponsesNew/components/ZapAmountModal.tsx
+++ b/packages/formstr-app/src/containers/ResponsesNew/components/ZapAmountModal.tsx
@@ -1,0 +1,86 @@
+import React, { useState } from "react";
+import { Modal, Button, InputNumber, Space, Typography } from "antd";
+import { ThunderboltOutlined } from "@ant-design/icons";
+
+const { Text } = Typography;
+
+const PRESETS = [21, 100, 500, 1000];
+
+interface ZapAmountModalProps {
+  open: boolean;
+  onCancel: () => void;
+  onConfirm: (amountSats: number) => void;
+  loading?: boolean;
+  recipientName?: string;
+}
+
+export const ZapAmountModal: React.FC<ZapAmountModalProps> = ({
+  open,
+  onCancel,
+  onConfirm,
+  loading = false,
+  recipientName,
+}) => {
+  const [amount, setAmount] = useState<number>(21);
+
+  return (
+    <Modal
+      title={
+        <Space>
+          <ThunderboltOutlined style={{ color: "#F7931A" }} />
+          <span>Zap {recipientName || "Responder"}</span>
+        </Space>
+      }
+      open={open}
+      onCancel={onCancel}
+      footer={[
+        <Button key="cancel" onClick={onCancel} disabled={loading}>
+          Cancel
+        </Button>,
+        <Button
+          key="zap"
+          type="primary"
+          onClick={() => onConfirm(amount)}
+          loading={loading}
+          icon={<ThunderboltOutlined />}
+          style={{ background: "#F7931A", borderColor: "#F7931A" }}
+        >
+          Zap {amount} sats
+        </Button>,
+      ]}
+      destroyOnClose
+    >
+      <div style={{ textAlign: "center", padding: "16px 0" }}>
+        <Text type="secondary" style={{ display: "block", marginBottom: 16 }}>
+          Choose an amount (sats)
+        </Text>
+        <Space wrap style={{ marginBottom: 16, justifyContent: "center" }}>
+          {PRESETS.map((preset) => (
+            <Button
+              key={preset}
+              type={amount === preset ? "primary" : "default"}
+              onClick={() => setAmount(preset)}
+              style={
+                amount === preset
+                  ? { background: "#F7931A", borderColor: "#F7931A" }
+                  : {}
+              }
+            >
+              {preset}
+            </Button>
+          ))}
+        </Space>
+        <div>
+          <InputNumber
+            min={1}
+            max={10_000_000}
+            value={amount}
+            onChange={(val) => val && setAmount(val)}
+            addonAfter="sats"
+            style={{ width: 200 }}
+          />
+        </div>
+      </div>
+    </Modal>
+  );
+};

--- a/packages/formstr-app/src/containers/ResponsesNew/components/ZapAmountModal.tsx
+++ b/packages/formstr-app/src/containers/ResponsesNew/components/ZapAmountModal.tsx
@@ -1,15 +1,15 @@
 import React, { useState } from "react";
-import { Modal, Button, InputNumber, Space, Typography } from "antd";
+import { Modal, Button, InputNumber, Input, Space, Typography } from "antd";
 import { ThunderboltOutlined } from "@ant-design/icons";
 
 const { Text } = Typography;
 
-const PRESETS = [21, 100, 500, 1000];
+const PRESETS = [21, 420, 1000, 5000, 10000, 15000];
 
 interface ZapAmountModalProps {
   open: boolean;
   onCancel: () => void;
-  onConfirm: (amountSats: number) => void;
+  onConfirm: (amountSats: number, comment: string) => void;
   loading?: boolean;
   recipientName?: string;
 }
@@ -22,6 +22,7 @@ export const ZapAmountModal: React.FC<ZapAmountModalProps> = ({
   recipientName,
 }) => {
   const [amount, setAmount] = useState<number>(21);
+  const [comment, setComment] = useState<string>("");
 
   return (
     <Modal
@@ -40,7 +41,7 @@ export const ZapAmountModal: React.FC<ZapAmountModalProps> = ({
         <Button
           key="zap"
           type="primary"
-          onClick={() => onConfirm(amount)}
+          onClick={() => onConfirm(amount, comment)}
           loading={loading}
           icon={<ThunderboltOutlined />}
           style={{ background: "#F7931A", borderColor: "#F7931A" }}
@@ -70,7 +71,7 @@ export const ZapAmountModal: React.FC<ZapAmountModalProps> = ({
             </Button>
           ))}
         </Space>
-        <div>
+        <div style={{ marginBottom: 16 }}>
           <InputNumber
             min={1}
             max={10_000_000}
@@ -78,6 +79,17 @@ export const ZapAmountModal: React.FC<ZapAmountModalProps> = ({
             onChange={(val) => val && setAmount(val)}
             addonAfter="sats"
             style={{ width: 200 }}
+          />
+        </div>
+        <div style={{ textAlign: "left" }}>
+          <Text type="secondary" style={{ display: "block", marginBottom: 4 }}>
+            Message (optional)
+          </Text>
+          <Input.TextArea
+            value={comment}
+            onChange={(e) => setComment(e.target.value)}
+            placeholder="thank you 👍"
+            rows={2}
           />
         </div>
       </div>

--- a/packages/formstr-app/src/containers/ResponsesNew/components/ZapButton.tsx
+++ b/packages/formstr-app/src/containers/ResponsesNew/components/ZapButton.tsx
@@ -77,9 +77,25 @@ export const ZapButton: React.FC<ZapButtonProps> = ({
     <>
       <Tooltip title="Zap this responder">
         <Button
-          type="text"
+          type="default"
           size={compact ? "small" : "middle"}
-          icon={<ThunderboltOutlined style={{ color: "#F7931A" }} />}
+          icon={
+            <ThunderboltOutlined
+              style={{
+                color: "#F7931A",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+            />
+          }
+          style={{
+            borderColor: "#F7931A",
+            color: "#F7931A",
+            display: "inline-flex",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
           onClick={(e) => {
             e.stopPropagation();
             setModalOpen(true);

--- a/packages/formstr-app/src/containers/ResponsesNew/components/ZapButton.tsx
+++ b/packages/formstr-app/src/containers/ResponsesNew/components/ZapButton.tsx
@@ -1,0 +1,107 @@
+import React, { useState } from "react";
+import { Button, Tooltip, Typography, message } from "antd";
+import { ThunderboltOutlined } from "@ant-design/icons";
+import { Event } from "nostr-tools";
+import {
+  ResponderProfile,
+  requestZapInvoice,
+  openLightningWallet,
+  ZapTotal,
+} from "../../../nostr/zaps";
+import { ZapAmountModal } from "./ZapAmountModal";
+
+const { Text } = Typography;
+
+interface ZapButtonProps {
+  /** The Kind-0 raw event of the responder */
+  recipientProfileEvent: Event | undefined;
+  /** Parsed profile data */
+  profile: ResponderProfile | undefined;
+  /** The response event to zap */
+  responseEvent: Event;
+  /** The parent form event (for "a" tag) */
+  formEvent: Event;
+  /** Accumulated zap total for this response */
+  zapTotal?: ZapTotal;
+  /** Relays to use */
+  relays?: string[];
+  /** Callback after zap initiated (to refresh totals) */
+  onZapInitiated?: () => void;
+  /** Compact mode for table cells */
+  compact?: boolean;
+}
+
+export const ZapButton: React.FC<ZapButtonProps> = ({
+  recipientProfileEvent,
+  profile,
+  responseEvent,
+  formEvent,
+  zapTotal,
+  relays,
+  onZapInitiated,
+  compact = false,
+}) => {
+  const [modalOpen, setModalOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  const handleZap = async (amountSats: number) => {
+    if (!recipientProfileEvent) return;
+    setLoading(true);
+    try {
+      const invoice = await requestZapInvoice({
+        recipientProfileEvent,
+        responseEvent,
+        formEvent,
+        amountMsats: amountSats * 1000,
+        relays,
+      });
+      openLightningWallet(invoice);
+      message.success("Lightning invoice opened in wallet");
+      setModalOpen(false);
+      onZapInitiated?.();
+    } catch (err: any) {
+      message.error(err?.message || "Failed to create zap");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const totalSats = zapTotal?.totalSats ?? 0;
+
+  return (
+    <>
+      <Tooltip title="Zap this responder">
+        <Button
+          type="text"
+          size={compact ? "small" : "middle"}
+          icon={<ThunderboltOutlined style={{ color: "#F7931A" }} />}
+          onClick={(e) => {
+            e.stopPropagation();
+            setModalOpen(true);
+          }}
+        >
+          {totalSats > 0 && (
+            <Text
+              style={{ fontSize: compact ? 11 : 13, color: "#F7931A" }}
+            >
+              {formatSats(totalSats)}
+            </Text>
+          )}
+        </Button>
+      </Tooltip>
+      <ZapAmountModal
+        open={modalOpen}
+        onCancel={() => setModalOpen(false)}
+        onConfirm={handleZap}
+        loading={loading}
+        recipientName={profile?.name}
+      />
+    </>
+  );
+};
+
+function formatSats(sats: number): string {
+  if (sats >= 1_000_000) return `${(sats / 1_000_000).toFixed(1)}M`;
+  if (sats >= 1_000) return `${(sats / 1_000).toFixed(1)}k`;
+  return `${sats}`;
+}

--- a/packages/formstr-app/src/containers/ResponsesNew/components/ZapButton.tsx
+++ b/packages/formstr-app/src/containers/ResponsesNew/components/ZapButton.tsx
@@ -5,7 +5,7 @@ import { Event } from "nostr-tools";
 import {
   ResponderProfile,
   requestZapInvoice,
-  openLightningWallet,
+  payInvoice,
   ZapTotal,
 } from "../../../nostr/zaps";
 import { ZapAmountModal } from "./ZapAmountModal";
@@ -44,7 +44,7 @@ export const ZapButton: React.FC<ZapButtonProps> = ({
   const [modalOpen, setModalOpen] = useState(false);
   const [loading, setLoading] = useState(false);
 
-  const handleZap = async (amountSats: number) => {
+  const handleZap = async (amountSats: number, comment: string) => {
     if (!recipientProfileEvent) return;
     setLoading(true);
     try {
@@ -53,10 +53,15 @@ export const ZapButton: React.FC<ZapButtonProps> = ({
         responseEvent,
         formEvent,
         amountMsats: amountSats * 1000,
+        comment,
         relays,
       });
-      openLightningWallet(invoice);
-      message.success("Lightning invoice opened in wallet");
+      const paidInBrowser = await payInvoice(invoice);
+      if (paidInBrowser) {
+        message.success("Zap sent successfully!");
+      } else {
+        message.info("Lightning invoice opened in wallet");
+      }
       setModalOpen(false);
       onZapInitiated?.();
     } catch (err: any) {

--- a/packages/formstr-app/src/containers/ResponsesNew/index.tsx
+++ b/packages/formstr-app/src/containers/ResponsesNew/index.tsx
@@ -405,47 +405,44 @@ export const Response = () => {
         width: isMobile() ? 100 : 130,
       },
       {
-        key: "zap",
-        title: "Zap",
+        key: "actions",
+        title: "Actions",
         dataIndex: "responseEventId",
-        width: 80,
+        fixed: "right",
+        width: 100,
         render: (_: string, record: any) => {
           const hexPubkey = record.responderHexPubkey;
           const profile = profiles.get(hexPubkey);
-          if (!hasLightningAddress(profile) || !formEvent) return <span>-</span>;
           const responseEventObj = responses?.find(
             (r) => r.id === record.responseEventId
           );
-          if (!responseEventObj) return <span>-</span>;
+          const canZap =
+            hasLightningAddress(profile) && !!formEvent && !!responseEventObj;
           return (
-            <ZapButton
-              recipientProfileEvent={profileEvents.get(hexPubkey)}
-              profile={profile}
-              responseEvent={responseEventObj}
-              formEvent={formEvent}
-              zapTotal={zapTotals.get(record.responseEventId)}
-              onZapInitiated={refreshZapTotals}
-              compact
-            />
+            <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
+              {canZap && (
+                <ZapButton
+                  recipientProfileEvent={profileEvents.get(hexPubkey)}
+                  profile={profile}
+                  responseEvent={responseEventObj!}
+                  formEvent={formEvent!}
+                  zapTotal={zapTotals.get(record.responseEventId)}
+                  onZapInitiated={refreshZapTotals}
+                  compact
+                />
+              )}
+              <div
+                style={{ cursor: "pointer", padding: "0 4px" }}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleRowClick(record);
+                }}
+              >
+                <ExportOutlined />
+              </div>
+            </div>
           );
         },
-      },
-      {
-        key: "action",
-        title: "Action",
-        dataIndex: "action",
-        fixed: "right",
-        width: 40,
-        render: (_: string, record: any) => (
-          <div
-            onClick={(e) => {
-              e.stopPropagation();
-              handleRowClick(record);
-            }}
-          >
-            <ExportOutlined />
-          </div>
-        ),
       },
     ];
     let uniqueQuestionIdsInResponses: Set<string> = new Set();

--- a/packages/formstr-app/src/containers/ResponsesNew/index.tsx
+++ b/packages/formstr-app/src/containers/ResponsesNew/index.tsx
@@ -31,6 +31,15 @@ import SafeMarkdown from "../../components/SafeMarkdown";
 import { ExportOutlined, DownloadOutlined } from "@ant-design/icons";
 import { decodeNKeys } from "../../utils/nkeys";
 import { downloadEncryptedFile } from "../../utils/fileDownload";
+import {
+  fetchProfiles,
+  fetchZapReceipts,
+  hasLightningAddress,
+  ResponderProfile,
+  ZapTotal,
+} from "../../nostr/zaps";
+import { ZapButton } from "./components/ZapButton";
+import { pool } from "../../pool";
 
 const { Text } = Typography;
 
@@ -76,6 +85,9 @@ export const Response = () => {
   const [isChatVisible, setIsChatVisible] = useState(false);
   const chatRef = useRef<HTMLDivElement>(null);
   const [isFormSpecLoading, setIsFormSpecLoading] = useState(true);
+  const [profiles, setProfiles] = useState<Map<string, ResponderProfile>>(new Map());
+  const [profileEvents, setProfileEvents] = useState<Map<string, Event>>(new Map());
+  const [zapTotals, setZapTotals] = useState<Map<string, ZapTotal>>(new Map());
 
   useEffect(() => {
     if (isChatVisible && chatRef.current) {
@@ -170,9 +182,64 @@ export const Response = () => {
     };
   }, [formEvent, formId]);
 
+  // Fetch Kind-0 profiles and zap receipts when responses change
+  useEffect(() => {
+    if (!responses || responses.length === 0) return;
+    const pubkeys = [...new Set(responses.map((r) => r.pubkey))];
+    const formRelays = formEvent ? getResponseRelays(formEvent) : undefined;
+
+    // Fetch profiles
+    fetchProfiles(pubkeys, formRelays).then((profileMap) => {
+      setProfiles(profileMap);
+    });
+
+    // Also store raw Kind-0 events for zap requests
+    const relayList = formRelays?.length ? formRelays : undefined;
+    pool
+      .querySync(relayList || [], { kinds: [0], authors: pubkeys })
+      .then((events) => {
+        const latest = new Map<string, Event>();
+        for (const ev of events) {
+          const existing = latest.get(ev.pubkey);
+          if (!existing || ev.created_at > existing.created_at) {
+            latest.set(ev.pubkey, ev);
+          }
+        }
+        setProfileEvents(latest);
+      });
+
+    // Fetch zap receipts
+    const responseIds = getLatestResponseIds();
+    if (responseIds.length > 0) {
+      fetchZapReceipts(responseIds, formRelays).then((totals) => {
+        setZapTotals(totals);
+      });
+    }
+  }, [responses, formEvent]);
+
   const getResponderCount = () => {
     if (!responses) return 0;
     return new Set(responses.map((r) => r.pubkey)).size;
+  };
+
+  /** Get latest response event ID per pubkey (for zap receipt lookup) */
+  const getLatestResponseIds = (): string[] => {
+    if (!responses) return [];
+    const perPubkey = new Map<string, Event>();
+    for (const r of responses) {
+      const existing = perPubkey.get(r.pubkey);
+      if (!existing || r.created_at > existing.created_at) {
+        perPubkey.set(r.pubkey, r);
+      }
+    }
+    return Array.from(perPubkey.values()).map((e) => e.id);
+  };
+
+  const refreshZapTotals = () => {
+    if (!responses || responses.length === 0) return;
+    const responseIds = getLatestResponseIds();
+    const formRelays = formEvent ? getResponseRelays(formEvent) : undefined;
+    fetchZapReceipts(responseIds, formRelays).then(setZapTotals);
   };
 
   const handleRowClick = (record: any) => {
@@ -273,6 +340,8 @@ export const Response = () => {
 
         answerObject[displayKey] = isFileField ? input[2] : responseLabel;
       });
+      answerObject["responseEventId"] = responseEvent.id;
+      answerObject["responderHexPubkey"] = responseEvent.pubkey;
       answers.push(answerObject);
     });
     return answers;
@@ -332,6 +401,32 @@ export const Response = () => {
         title: "Submitted At",
         dataIndex: "createdAt",
         width: isMobile() ? 100 : 130,
+      },
+      {
+        key: "zap",
+        title: "Zap",
+        dataIndex: "responseEventId",
+        width: 80,
+        render: (_: string, record: any) => {
+          const hexPubkey = record.responderHexPubkey;
+          const profile = profiles.get(hexPubkey);
+          if (!hasLightningAddress(profile) || !formEvent) return <span>-</span>;
+          const responseEventObj = responses?.find(
+            (r) => r.id === record.responseEventId
+          );
+          if (!responseEventObj) return <span>-</span>;
+          return (
+            <ZapButton
+              recipientProfileEvent={profileEvents.get(hexPubkey)}
+              profile={profile}
+              responseEvent={responseEventObj}
+              formEvent={formEvent}
+              zapTotal={zapTotals.get(record.responseEventId)}
+              onZapInitiated={refreshZapTotals}
+              compact
+            />
+          );
+        },
       },
       {
         key: "action",
@@ -475,7 +570,9 @@ export const Response = () => {
           height: "80vh",
         }}
       >
-        <Spin size="large" tip="Loading form details..." />
+        <Spin size="large" tip="Loading form details...">
+          <div style={{ minHeight: 60 }} />
+        </Spin>
       </div>
     );
   }
@@ -580,6 +677,23 @@ export const Response = () => {
             responseMetadataEvent={selectedEventForModal}
             formstrBranding={getformstrBranding(formSpec)}
             editKey={editKey}
+            formEvent={formEvent}
+            recipientProfileEvent={
+              selectedEventForModal
+                ? profileEvents.get(selectedEventForModal.pubkey)
+                : undefined
+            }
+            profile={
+              selectedEventForModal
+                ? profiles.get(selectedEventForModal.pubkey)
+                : undefined
+            }
+            zapTotal={
+              selectedEventForModal
+                ? zapTotals.get(selectedEventForModal.id)
+                : undefined
+            }
+            onZapInitiated={refreshZapTotals}
           />
         )}
     </div>

--- a/packages/formstr-app/src/containers/ResponsesNew/index.tsx
+++ b/packages/formstr-app/src/containers/ResponsesNew/index.tsx
@@ -370,18 +370,39 @@ export const Response = () => {
         title: "Author",
         fixed: "left",
         dataIndex: "authorPubkey",
-        width: isMobile() ? 120 : 150,
-        render: (data: string) => (
-          <a
-            href={`https://njump.me/${data}`}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            {isMobile()
-              ? `${data.substring(0, 10)}...${data.substring(data.length - 5)}`
-              : data}
-          </a>
-        ),
+        width: isMobile() ? 150 : 220,
+        render: (data: string, record: any) => {
+          const hexPubkey = record.responderHexPubkey;
+          const profile = profiles.get(hexPubkey);
+          const responseEventObj = responses?.find(
+            (r) => r.id === record.responseEventId
+          );
+          const canZap =
+            hasLightningAddress(profile) && !!formEvent && !!responseEventObj;
+          return (
+            <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+              <a
+                href={`https://njump.me/${data}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                title={data}
+              >
+                {`${data.substring(0, 10)}…${data.substring(data.length - 6)}`}
+              </a>
+              {canZap && (
+                <ZapButton
+                  recipientProfileEvent={profileEvents.get(hexPubkey)}
+                  profile={profile}
+                  responseEvent={responseEventObj!}
+                  formEvent={formEvent!}
+                  zapTotal={zapTotals.get(record.responseEventId)}
+                  onZapInitiated={refreshZapTotals}
+                  compact
+                />
+              )}
+            </div>
+          );
+        },
       },
       {
         key: "responsesCount",
@@ -405,44 +426,22 @@ export const Response = () => {
         width: isMobile() ? 100 : 130,
       },
       {
-        key: "actions",
-        title: "Actions",
-        dataIndex: "responseEventId",
+        key: "action",
+        title: "Action",
+        dataIndex: "action",
         fixed: "right",
-        width: 100,
-        render: (_: string, record: any) => {
-          const hexPubkey = record.responderHexPubkey;
-          const profile = profiles.get(hexPubkey);
-          const responseEventObj = responses?.find(
-            (r) => r.id === record.responseEventId
-          );
-          const canZap =
-            hasLightningAddress(profile) && !!formEvent && !!responseEventObj;
-          return (
-            <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
-              {canZap && (
-                <ZapButton
-                  recipientProfileEvent={profileEvents.get(hexPubkey)}
-                  profile={profile}
-                  responseEvent={responseEventObj!}
-                  formEvent={formEvent!}
-                  zapTotal={zapTotals.get(record.responseEventId)}
-                  onZapInitiated={refreshZapTotals}
-                  compact
-                />
-              )}
-              <div
-                style={{ cursor: "pointer", padding: "0 4px" }}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  handleRowClick(record);
-                }}
-              >
-                <ExportOutlined />
-              </div>
-            </div>
-          );
-        },
+        width: 60,
+        render: (_: string, record: any) => (
+          <div
+            style={{ cursor: "pointer" }}
+            onClick={(e) => {
+              e.stopPropagation();
+              handleRowClick(record);
+            }}
+          >
+            <ExportOutlined />
+          </div>
+        ),
       },
     ];
     let uniqueQuestionIdsInResponses: Set<string> = new Set();

--- a/packages/formstr-app/src/containers/ResponsesNew/index.tsx
+++ b/packages/formstr-app/src/containers/ResponsesNew/index.tsx
@@ -38,6 +38,7 @@ import {
   ResponderProfile,
   ZapTotal,
 } from "../../nostr/zaps";
+import { getDefaultRelays } from "../../nostr/common";
 import { ZapButton } from "./components/ZapButton";
 import { pool } from "../../pool";
 
@@ -188,15 +189,16 @@ export const Response = () => {
     const pubkeys = [...new Set(responses.map((r) => r.pubkey))];
     const formRelays = formEvent ? getResponseRelays(formEvent) : undefined;
 
-    // Fetch profiles
     fetchProfiles(pubkeys, formRelays).then((profileMap) => {
       setProfiles(profileMap);
     });
 
     // Also store raw Kind-0 events for zap requests
-    const relayList = formRelays?.length ? formRelays : undefined;
     pool
-      .querySync(relayList || [], { kinds: [0], authors: pubkeys })
+      .querySync(
+        [...new Set([...(formRelays || []), ...getDefaultRelays()])],
+        { kinds: [0], authors: pubkeys },
+      )
       .then((events) => {
         const latest = new Map<string, Event>();
         for (const ev of events) {

--- a/packages/formstr-app/src/nostr/zaps.ts
+++ b/packages/formstr-app/src/nostr/zaps.ts
@@ -1,6 +1,7 @@
 import { Event, EventTemplate, Filter } from "nostr-tools";
 import {
   getZapEndpoint,
+  getSatoshisAmountFromBolt11,
   makeZapRequest,
   validateZapRequest,
 } from "nostr-tools/nip57";
@@ -16,6 +17,15 @@ export interface ResponderProfile {
   lud06?: string;
 }
 
+// Relays known to index Kind-0 profile events
+const PROFILE_RELAYS = [
+  "wss://purplepag.es",
+  "wss://relay.nostr.band",
+  "wss://relay.damus.io",
+  "wss://relay.primal.net",
+  "wss://nos.lol",
+];
+
 /**
  * Batch-fetch Kind-0 profiles for a list of pubkeys.
  * Returns a Map of hex-pubkey → parsed profile metadata.
@@ -24,12 +34,16 @@ export async function fetchProfiles(
   pubkeys: string[],
   relays?: string[],
 ): Promise<Map<string, ResponderProfile>> {
-  const relayList = relays?.length ? relays : getDefaultRelays();
+  const merged = [...new Set([
+    ...(relays || []),
+    ...PROFILE_RELAYS,
+    ...getDefaultRelays(),
+  ])];
   const unique = [...new Set(pubkeys)];
   if (unique.length === 0) return new Map();
 
   const filter: Filter = { kinds: [0], authors: unique };
-  const events = await pool.querySync(relayList, filter);
+  const events = await pool.querySync(merged, filter);
 
   // Keep newest event per pubkey
   const latest = new Map<string, Event>();
@@ -51,7 +65,7 @@ export async function fetchProfiles(
         lud06: parsed.lud06,
       });
     } catch {
-      // Malformed profile – skip
+      // skip unparseable profiles
     }
   }
   return profiles;
@@ -126,10 +140,12 @@ export async function requestZapInvoice(
   }
 
   // 4. Call the LNURL callback
-  const encodedZapRequest = encodeURIComponent(JSON.stringify(signedZapRequest));
-  const separator = callback.includes("?") ? "&" : "?";
-  const url = `${callback}${separator}amount=${amountMsats}&nostr=${encodedZapRequest}`;
-  const response = await fetch(url);
+  const url = new URL(callback);
+  url.searchParams.set("amount", amountMsats.toString());
+  url.searchParams.set("nostr", JSON.stringify(signedZapRequest));
+  if (comment) url.searchParams.set("comment", comment);
+
+  const response = await fetch(url.toString());
   if (!response.ok) {
     throw new Error(`LNURL callback failed: ${response.status}`);
   }
@@ -145,62 +161,48 @@ export async function requestZapInvoice(
 }
 
 /**
- * Open a lightning wallet with the given bolt11 invoice.
- * Tries the `lightning:` URI scheme. Falls back to clipboard copy.
+ * Pay a bolt11 invoice. Tries WebLN (in-browser payment via Alby etc.)
+ * first, then falls back to opening a lightning: URI.
+ * Returns true if paid in-browser via WebLN.
  */
-export function openLightningWallet(invoice: string): void {
+export async function payInvoice(invoice: string): Promise<boolean> {
+  const webln = typeof window !== "undefined" ? (window as any).webln : null;
+  if (webln) {
+    try {
+      await webln.enable();
+      await webln.sendPayment(invoice);
+      return true;
+    } catch {
+      // WebLN failed or user rejected — fall through to URI
+    }
+  }
   window.open(`lightning:${invoice}`, "_self");
+  return false;
 }
 
 // ── Zap receipt helpers ──────────────────────────────────────────────
 
 /**
- * Parse the sats amount from the bolt11 tag inside a Kind-9735 zap receipt.
- * Returns 0 if unparseable.
+ * Extract sats from a Kind-9735 zap receipt.
+ * Prefers the `amount` tag (msats), falls back to bolt11 parsing.
  */
 function satoshisFromReceipt(event: Event): number {
-  const bolt11Tag = event.tags.find((t) => t[0] === "bolt11");
-  if (!bolt11Tag || !bolt11Tag[1]) return 0;
-  // nostr-tools provides a parser, but it's not re-exported cleanly.
-  // Parse manually: strip "lnbc", read amount + multiplier.
-  return parseBolt11Amount(bolt11Tag[1]);
-}
-
-export function parseBolt11Amount(bolt11: string): number {
-  if (!bolt11 || bolt11.length < 6) return 0;
-  const lower = bolt11.toLowerCase();
-  if (!lower.startsWith("lnbc")) return 0;
-
-  // Find the last "1" separator — everything before it is hrp
-  const lastOne = lower.lastIndexOf("1");
-  if (lastOne < 5) return 0;
-  const hrp = lower.substring(4, lastOne);
-  if (hrp.length === 0) return 0;
-
-  // The multiplier is the last non-digit character
-  const multiplierChar = hrp[hrp.length - 1];
-  const multipliers: Record<string, number> = {
-    m: 100_000,     // milli-BTC → sats
-    u: 100,         // micro-BTC → sats
-    n: 0.1,         // nano-BTC → sats
-    p: 0.0001,      // pico-BTC → sats
-  };
-
-  let amountStr: string;
-  let multiplier: number;
-
-  if (multipliers[multiplierChar] !== undefined) {
-    amountStr = hrp.substring(0, hrp.length - 1);
-    multiplier = multipliers[multiplierChar];
-  } else {
-    // No multiplier — amount is in BTC
-    amountStr = hrp;
-    multiplier = 100_000_000; // BTC → sats
+  // Prefer the `amount` tag (value is in millisats)
+  const amountTag = event.tags.find((t) => t[0] === "amount");
+  if (amountTag?.[1]) {
+    const msats = parseInt(amountTag[1], 10);
+    if (!isNaN(msats)) return Math.round(msats / 1000);
   }
-
-  const parsed = parseInt(amountStr, 10);
-  if (isNaN(parsed)) return 0;
-  return Math.round(parsed * multiplier);
+  // Fallback: parse the bolt11 invoice
+  const bolt11Tag = event.tags.find((t) => t[0] === "bolt11");
+  if (bolt11Tag?.[1]) {
+    try {
+      return getSatoshisAmountFromBolt11(bolt11Tag[1]);
+    } catch {
+      return 0;
+    }
+  }
+  return 0;
 }
 
 export interface ZapTotal {
@@ -230,7 +232,6 @@ export async function fetchZapReceipts(
   const totals = new Map<string, ZapTotal>();
 
   for (const ev of events) {
-    // Find which response event this receipt is for
     const eTag = ev.tags.find((t) => t[0] === "e");
     if (!eTag?.[1]) continue;
     const responseId = eTag[1];

--- a/packages/formstr-app/src/nostr/zaps.ts
+++ b/packages/formstr-app/src/nostr/zaps.ts
@@ -1,0 +1,247 @@
+import { Event, EventTemplate, Filter } from "nostr-tools";
+import {
+  getZapEndpoint,
+  makeZapRequest,
+  validateZapRequest,
+} from "nostr-tools/nip57";
+import { pool } from "../pool";
+import { getDefaultRelays, signEvent } from "./common";
+
+// ── Profile helpers ──────────────────────────────────────────────────
+
+export interface ResponderProfile {
+  name?: string;
+  picture?: string;
+  lud16?: string;
+  lud06?: string;
+}
+
+/**
+ * Batch-fetch Kind-0 profiles for a list of pubkeys.
+ * Returns a Map of hex-pubkey → parsed profile metadata.
+ */
+export async function fetchProfiles(
+  pubkeys: string[],
+  relays?: string[],
+): Promise<Map<string, ResponderProfile>> {
+  const relayList = relays?.length ? relays : getDefaultRelays();
+  const unique = [...new Set(pubkeys)];
+  if (unique.length === 0) return new Map();
+
+  const filter: Filter = { kinds: [0], authors: unique };
+  const events = await pool.querySync(relayList, filter);
+
+  // Keep newest event per pubkey
+  const latest = new Map<string, Event>();
+  for (const ev of events) {
+    const existing = latest.get(ev.pubkey);
+    if (!existing || ev.created_at > existing.created_at) {
+      latest.set(ev.pubkey, ev);
+    }
+  }
+
+  const profiles = new Map<string, ResponderProfile>();
+  for (const [pk, ev] of latest) {
+    try {
+      const parsed = JSON.parse(ev.content);
+      profiles.set(pk, {
+        name: parsed.name ?? parsed.display_name,
+        picture: parsed.picture,
+        lud16: parsed.lud16,
+        lud06: parsed.lud06,
+      });
+    } catch {
+      // Malformed profile – skip
+    }
+  }
+  return profiles;
+}
+
+/**
+ * Whether a profile has a lightning address we can zap.
+ */
+export function hasLightningAddress(profile?: ResponderProfile): boolean {
+  if (!profile) return false;
+  return !!(profile.lud16 || profile.lud06);
+}
+
+// ── Zap request / invoice flow ───────────────────────────────────────
+
+export interface ZapParams {
+  /** The Kind-0 event of the person being zapped */
+  recipientProfileEvent: Event;
+  /** The response event being zapped */
+  responseEvent: Event;
+  /** The form template event (for the "a" tag reference) */
+  formEvent: Event;
+  /** Amount in millisats */
+  amountMsats: number;
+  /** Optional comment attached to the zap */
+  comment?: string;
+  /** Relays to include in the zap request tags */
+  relays?: string[];
+}
+
+/**
+ * Full zap flow:
+ * 1. Resolve the LNURL callback from the recipient's Kind-0 event.
+ * 2. Build and sign a Kind-9734 zap request.
+ * 3. Call the LNURL callback with amount + zap request to get a bolt11 invoice.
+ * 4. Return the invoice string so the caller can open a wallet.
+ */
+export async function requestZapInvoice(
+  params: ZapParams,
+): Promise<string> {
+  const {
+    recipientProfileEvent,
+    responseEvent,
+    formEvent,
+    amountMsats,
+    comment,
+    relays,
+  } = params;
+  const relayList = relays?.length ? relays : getDefaultRelays();
+
+  // 1. Resolve LNURL callback
+  const callback = await getZapEndpoint(recipientProfileEvent);
+  if (!callback) {
+    throw new Error("Recipient has no valid LNURL/lud16 endpoint");
+  }
+
+  // 2. Build zap request (unsigned event template)
+  const zapRequestTemplate: EventTemplate = makeZapRequest({
+    event: responseEvent,
+    amount: amountMsats,
+    relays: relayList,
+    comment: comment || "",
+  });
+
+  // 3. Sign it with the current user's signer
+  const signedZapRequest = await signEvent(zapRequestTemplate, null);
+
+  // Validate our own zap request
+  const validationError = validateZapRequest(JSON.stringify(signedZapRequest));
+  if (validationError) {
+    throw new Error(`Invalid zap request: ${validationError}`);
+  }
+
+  // 4. Call the LNURL callback
+  const encodedZapRequest = encodeURIComponent(JSON.stringify(signedZapRequest));
+  const separator = callback.includes("?") ? "&" : "?";
+  const url = `${callback}${separator}amount=${amountMsats}&nostr=${encodedZapRequest}`;
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`LNURL callback failed: ${response.status}`);
+  }
+  const body = await response.json();
+  if (body.status === "ERROR") {
+    throw new Error(body.reason || "LNURL provider returned error");
+  }
+  if (!body.pr) {
+    throw new Error("No invoice returned by LNURL provider");
+  }
+
+  return body.pr as string;
+}
+
+/**
+ * Open a lightning wallet with the given bolt11 invoice.
+ * Tries the `lightning:` URI scheme. Falls back to clipboard copy.
+ */
+export function openLightningWallet(invoice: string): void {
+  window.open(`lightning:${invoice}`, "_self");
+}
+
+// ── Zap receipt helpers ──────────────────────────────────────────────
+
+/**
+ * Parse the sats amount from the bolt11 tag inside a Kind-9735 zap receipt.
+ * Returns 0 if unparseable.
+ */
+function satoshisFromReceipt(event: Event): number {
+  const bolt11Tag = event.tags.find((t) => t[0] === "bolt11");
+  if (!bolt11Tag || !bolt11Tag[1]) return 0;
+  // nostr-tools provides a parser, but it's not re-exported cleanly.
+  // Parse manually: strip "lnbc", read amount + multiplier.
+  return parseBolt11Amount(bolt11Tag[1]);
+}
+
+export function parseBolt11Amount(bolt11: string): number {
+  if (!bolt11 || bolt11.length < 6) return 0;
+  const lower = bolt11.toLowerCase();
+  if (!lower.startsWith("lnbc")) return 0;
+
+  // Find the last "1" separator — everything before it is hrp
+  const lastOne = lower.lastIndexOf("1");
+  if (lastOne < 5) return 0;
+  const hrp = lower.substring(4, lastOne);
+  if (hrp.length === 0) return 0;
+
+  // The multiplier is the last non-digit character
+  const multiplierChar = hrp[hrp.length - 1];
+  const multipliers: Record<string, number> = {
+    m: 100_000,     // milli-BTC → sats
+    u: 100,         // micro-BTC → sats
+    n: 0.1,         // nano-BTC → sats
+    p: 0.0001,      // pico-BTC → sats
+  };
+
+  let amountStr: string;
+  let multiplier: number;
+
+  if (multipliers[multiplierChar] !== undefined) {
+    amountStr = hrp.substring(0, hrp.length - 1);
+    multiplier = multipliers[multiplierChar];
+  } else {
+    // No multiplier — amount is in BTC
+    amountStr = hrp;
+    multiplier = 100_000_000; // BTC → sats
+  }
+
+  const parsed = parseInt(amountStr, 10);
+  if (isNaN(parsed)) return 0;
+  return Math.round(parsed * multiplier);
+}
+
+export interface ZapTotal {
+  totalSats: number;
+  count: number;
+}
+
+/**
+ * Fetch Kind-9735 zap receipts for a set of response event IDs.
+ * Returns a Map of responseEventId → { totalSats, count }.
+ */
+export async function fetchZapReceipts(
+  responseEventIds: string[],
+  relays?: string[],
+): Promise<Map<string, ZapTotal>> {
+  const relayList = relays?.length ? relays : getDefaultRelays();
+  const unique = [...new Set(responseEventIds)];
+  if (unique.length === 0) return new Map();
+
+  const filter: Filter = {
+    kinds: [9735],
+    "#e": unique,
+  };
+
+  const events = await pool.querySync(relayList, filter);
+
+  const totals = new Map<string, ZapTotal>();
+
+  for (const ev of events) {
+    // Find which response event this receipt is for
+    const eTag = ev.tags.find((t) => t[0] === "e");
+    if (!eTag?.[1]) continue;
+    const responseId = eTag[1];
+    if (!unique.includes(responseId)) continue;
+
+    const sats = satoshisFromReceipt(ev);
+    const existing = totals.get(responseId) || { totalSats: 0, count: 0 };
+    existing.totalSats += sats;
+    existing.count += 1;
+    totals.set(responseId, existing);
+  }
+
+  return totals;
+}


### PR DESCRIPTION
- Fetch Kind-0 profiles for responders to check lightning address (lud16/lud06)
- Show zap button for responses where responder has a lightning address
- Create NIP-57 zap request (Kind-9734) and open lightning wallet via URI
- Fetch zap receipts (Kind-9735) and display accumulated totals per response
- Add ZapButton and ZapAmountModal components
- Integrate zap into response table and detail modal

Solves #271 

## Screenshots
<img width="1600" height="892" alt="image" src="https://github.com/user-attachments/assets/514cd97b-a664-46bc-b473-4d2ab37c95fd" />
<img width="553" height="314" alt="image" src="https://github.com/user-attachments/assets/f8d68e01-6fa0-4b0e-927f-592a35b781fa" />
