### PR TITLE
feat: formstr Support Us NIP-57 Zap integration

### DIFF
--- a/packages/formstr-app/config/webpack.config.js
+++ b/packages/formstr-app/config/webpack.config.js
@@ -335,6 +335,7 @@ module.exports = function getWebpackConfig(webpackEnv, {inlineScripts, entry, ou
           babelRuntimeEntry,
           babelRuntimeEntryHelpers,
           babelRuntimeRegenerator,
+          path.resolve(__dirname, '../../formstr-support-us-button/src'),
         ]),
       ],
     },
@@ -407,7 +408,11 @@ module.exports = function getWebpackConfig(webpackEnv, {inlineScripts, entry, ou
             // The preset includes JSX, Flow, TypeScript, and some ESnext features.
             {
               test: /\.(js|mjs|jsx|ts|tsx)$/,
-              include: paths.appSrc,
+              include: [
+                paths.appSrc,
+                // Also transpile our local monorepo package which ships raw TSX
+                path.resolve(__dirname, '../../formstr-support-us-button/src'),
+              ],
               loader: require.resolve('babel-loader'),
               options: {
                 customize: require.resolve(

--- a/packages/formstr-app/package.json
+++ b/packages/formstr-app/package.json
@@ -80,7 +80,8 @@
     "webpack-dev-server": "^4.6.0",
     "webpack-manifest-plugin": "^4.0.2",
     "workbox-webpack-plugin": "^6.4.1",
-    "xlsx": "^0.18.5"
+    "xlsx": "^0.18.5",
+    "@formstr/support-us-button": "*"
   },
   "scripts": {
     "predeploy": "npm run build",

--- a/packages/formstr-app/src/components/Header/index.tsx
+++ b/packages/formstr-app/src/components/Header/index.tsx
@@ -33,6 +33,7 @@ import ThemedUniversalModal from "../UniversalMarkdownModal";
 import { nip19 } from "nostr-tools";
 import { useTranslation } from "react-i18next";
 import { changeAppLanguage, normalizeLocale, SUPPORTED_LOCALES } from "../../i18n";
+import { SupportUsButton, SupportUsModal } from "@formstr/support-us-button";
 
 const { Text, Paragraph } = Typography;
 
@@ -58,6 +59,7 @@ export const NostrHeader = () => {
   } = useLocalForms();
   const [isFAQModalVisible, setIsFAQModalVisible] = useState(false);
   const [showEncryptionModal, setShowEncryptionModal] = useState(false);
+  const [showSupportModal, setShowSupportModal] = useState(false);
   const [encryptionLoading, setEncryptionLoading] = useState(false);
   const [languageLoading, setLanguageLoading] = useState(false);
   const [selectedKey, setSelectedKey] = useState<string[]>([]);
@@ -303,7 +305,7 @@ export const NostrHeader = () => {
     }
 
     if (key === "support-us") {
-      window.open("https://geyser.fund/project/formstr", "_blank");
+      setShowSupportModal(true);
       return;
     }
 
@@ -412,6 +414,7 @@ export const NostrHeader = () => {
       </div>
     ),
   };
+
   const newHeaderMenu = [...getHeaderMenu(t), User];
   return (
     <>
@@ -422,13 +425,13 @@ export const NostrHeader = () => {
           borderBottom: "1px solid #ddd",
         }}
       >
-        <Row className="header-row" justify="space-between">
+        <Row className="header-row" justify="space-between" align="middle">
           <Col>
             <Link className="app-link" to="/">
               <Logo />
             </Link>
           </Col>
-          <Col md={12} xs={10} sm={2}>
+          <Col md={12} xs={10} sm={2} style={{ display: "flex", alignItems: "center" }}>
             <Menu
               mode="horizontal"
               theme="light"
@@ -437,6 +440,11 @@ export const NostrHeader = () => {
               overflowedIndicator={<MenuOutlined />}
               items={newHeaderMenu}
               onClick={onMenuClick}
+              style={{ flex: 1 }}
+            />
+            <SupportUsButton
+              type="text"
+              style={{ flexShrink: 0, marginLeft: 4 }}
             />
           </Col>
         </Row>
@@ -458,6 +466,11 @@ export const NostrHeader = () => {
       >
         {renderEncryptionModalContent()}
       </Modal>
+      <SupportUsModal
+        open={showSupportModal}
+        npub="npub1qu7dsd44275lms4x9snnwvnnmgx926nsppmr7lcw9dlj36n4fltqgs7p98"
+        onClose={() => setShowSupportModal(false)}
+      />
     </>
   );
 };

--- a/packages/formstr-app/src/components/Header/index.tsx
+++ b/packages/formstr-app/src/components/Header/index.tsx
@@ -21,19 +21,19 @@ import {
   WarningOutlined,
   ExclamationCircleOutlined,
   GlobalOutlined,
+  ThunderboltOutlined,
 } from "@ant-design/icons";
 import { getHeaderMenu, HEADER_MENU_KEYS } from "./configs";
 import { useProfileContext } from "../../hooks/useProfileContext";
 import { useLocalForms } from "../../provider/LocalFormsProvider";
 import { NostrAvatar } from "./NostrAvatar";
-import { ReactComponent as GeyserIcon } from "../../Images/Geyser.svg";
 import { useState } from "react";
 import { useTemplateContext } from "../../provider/TemplateProvider";
 import ThemedUniversalModal from "../UniversalMarkdownModal";
 import { nip19 } from "nostr-tools";
 import { useTranslation } from "react-i18next";
 import { changeAppLanguage, normalizeLocale, SUPPORTED_LOCALES } from "../../i18n";
-import { SupportUsButton, SupportUsModal } from "@formstr/support-us-button";
+import { SupportUsModal } from "@formstr/support-us-button";
 
 const { Text, Paragraph } = Typography;
 
@@ -351,31 +351,8 @@ export const NostrHeader = () => {
     },
     {
       key: "support-us",
-      icon: (
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "row",
-            justifyContent: "space-between",
-          }}
-        >
-          <GeyserIcon
-            style={{
-              color: "white",
-              strokeWidth: 20,
-              fill: "black",
-              stroke: "black",
-              maxHeight: 20,
-              maxWidth: 20,
-              backgroundColor: "black",
-              marginRight: 5,
-            }}
-          />
-          <Typography.Text style={{ marginTop: 2 }}>
-            {t("header.supportUs")}
-          </Typography.Text>
-        </div>
-      ),
+      icon: <ThunderboltOutlined style={{ color: "#fadb14" }} />,
+      label: t("header.supportUs"),
     },
     {
       key: "language",
@@ -441,10 +418,6 @@ export const NostrHeader = () => {
               items={newHeaderMenu}
               onClick={onMenuClick}
               style={{ flex: 1 }}
-            />
-            <SupportUsButton
-              type="text"
-              style={{ flexShrink: 0, marginLeft: 4 }}
             />
           </Col>
         </Row>

--- a/packages/formstr-app/src/containers/CreateFormNew/components/FormDetails/ShareTab.tsx
+++ b/packages/formstr-app/src/containers/CreateFormNew/components/FormDetails/ShareTab.tsx
@@ -1,5 +1,9 @@
 import { UrlBox } from "./UrlBox";
 import { ReactComponent as Success } from "../../../../Images/success.svg";
+import { Typography } from "antd";
+import { SupportUsButton } from "@formstr/support-us-button";
+
+const { Text } = Typography;
 
 export const ShareTab = ({
   formUrl,
@@ -25,6 +29,18 @@ export const ShareTab = ({
           </>
         )}
       </div>
+
+      <Text
+        type="secondary"
+        style={{ display: "block", marginTop: 20, fontSize: 12 }}
+      >
+        Enjoying Formstr?{" "}
+        <SupportUsButton
+          buttonText="Support Us"
+          type="link"
+          style={{ fontSize: 12, padding: 0, height: "auto" }}
+        />
+      </Text>
     </div>
   );
 };

--- a/packages/formstr-support-us-button/package.json
+++ b/packages/formstr-support-us-button/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@formstr/support-us-button",
+  "version": "1.0.0",
+  "main": "src/index.tsx",
+  "types": "src/index.tsx",
+  "scripts": {
+    "build": "tsc"
+  },
+  "dependencies": {
+    "antd": "^5.11.2",
+    "nostr-tools": "^2.16.2",
+    "qrcode.react": "^3.1.0"
+  },
+  "peerDependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.2.2"
+  }
+}

--- a/packages/formstr-support-us-button/src/SupportUsButton.tsx
+++ b/packages/formstr-support-us-button/src/SupportUsButton.tsx
@@ -1,0 +1,46 @@
+import React, { useState, useEffect } from 'react';
+import { Button } from 'antd';
+import { ThunderboltOutlined } from '@ant-design/icons';
+import { SupportUsModal, prefetchSupportInfo } from './SupportUsModal';
+
+const FORMSTR_NPUB = 'npub1qu7dsd44275lms4x9snnwvnnmgx926nsppmr7lcw9dlj36n4fltqgs7p98';
+
+interface SupportUsButtonProps {
+  npub?: string;
+  buttonText?: string;
+  type?: 'primary' | 'default' | 'dashed' | 'link' | 'text';
+  style?: React.CSSProperties;
+}
+
+export const SupportUsButton: React.FC<SupportUsButtonProps> = ({
+  npub = FORMSTR_NPUB,
+  buttonText = 'Support Us',
+  type = 'default',
+  style,
+}) => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  useEffect(() => {
+    prefetchSupportInfo(npub);
+  }, [npub]);
+
+  return (
+    <>
+      <Button
+        type={type}
+        onClick={() => setIsModalOpen(true)}
+        style={style}
+      >
+        <span>{buttonText}</span>
+        {/* Override Ant Design's automatic gap behavior with inline styles */}
+        <ThunderboltOutlined style={{ color: '#fadb14', marginLeft: '4px' }} />
+      </Button>
+
+      <SupportUsModal
+        open={isModalOpen}
+        npub={npub}
+        onClose={() => setIsModalOpen(false)}
+      />
+    </>
+  );
+};

--- a/packages/formstr-support-us-button/src/SupportUsModal.tsx
+++ b/packages/formstr-support-us-button/src/SupportUsModal.tsx
@@ -1,0 +1,305 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { Modal, InputNumber, Button, Typography, message, Spin, Alert, Tooltip, Divider } from 'antd';
+import { QRCodeSVG } from 'qrcode.react';
+import { nip19, SimplePool } from 'nostr-tools';
+import { CopyOutlined, ThunderboltOutlined } from '@ant-design/icons';
+
+const { Text, Title } = Typography;
+
+// Define relays to fetch kind 0
+const RELAYS = ['wss://purplepag.es', 'wss://relay.damus.io', 'wss://relay.nostr.band'];
+
+// Module-level cache — shared across all instances, persists for the session
+interface LNCache {
+  lud16: string;
+  zapEndpoint: string;
+}
+const lnCache: Record<string, LNCache> = {};
+
+// Eagerly fetches and caches the LN endpoint for a given npub
+export const prefetchSupportInfo = async (npub: string): Promise<void> => {
+  if (lnCache[npub]) return; // already cached
+
+  try {
+    const { type, data } = nip19.decode(npub);
+    if (type !== 'npub') return;
+    const decodedPubkey = data as string;
+
+    const pool = new SimplePool();
+    const profileEvent = await pool.get(RELAYS, {
+      kinds: [0],
+      authors: [decodedPubkey],
+    });
+    pool.close(RELAYS);
+
+    if (!profileEvent) return;
+
+    const content = JSON.parse(profileEvent.content);
+    const lud16Address = content.lud16 || content.lud06;
+    if (!lud16Address) return;
+
+    const [name, domain] = lud16Address.split('@');
+    if (!domain) return;
+
+    const endpointUrl = `https://${domain}/.well-known/lnurlp/${name}`;
+    const res = await fetch(endpointUrl);
+    const lnData = await res.json();
+
+    if (lnData.callback) {
+      lnCache[npub] = { lud16: lud16Address, zapEndpoint: lnData.callback };
+    }
+  } catch {
+    // Silently fail — modal will fetch on demand if cache is empty
+  }
+};
+
+interface SupportUsModalProps {
+  open: boolean;
+  npub: string;
+  onClose: () => void;
+}
+
+export const SupportUsModal: React.FC<SupportUsModalProps> = ({ open, npub, onClose }) => {
+  const [amountSats, setAmountSats] = useState<number | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [invoice, setInvoice] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [zapEndpoint, setZapEndpoint] = useState<string | null>(null);
+  const [lud16, setLud16] = useState<string | null>(null);
+
+  // Load from cache or fetch on first open
+  useEffect(() => {
+    if (!open) {
+      setInvoice(null);
+      setError(null);
+      return;
+    }
+
+    // If already cached, apply instantly — no spinner
+    if (lnCache[npub]) {
+      setLud16(lnCache[npub].lud16);
+      setZapEndpoint(lnCache[npub].zapEndpoint);
+      return;
+    }
+
+    // Fallback: fetch now (in case prefetch hasn't completed yet)
+    const fetchProfile = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const { type, data } = nip19.decode(npub);
+        if (type !== 'npub') throw new Error('Invalid npub provided');
+        const decodedPubkey = data as string;
+
+        const pool = new SimplePool();
+        const profileEvent = await pool.get(RELAYS, {
+          kinds: [0],
+          authors: [decodedPubkey],
+        });
+        pool.close(RELAYS);
+
+        if (!profileEvent) throw new Error('Could not find Nostr profile for this npub');
+
+        const content = JSON.parse(profileEvent.content);
+        const lud16Address = content.lud16 || content.lud06;
+        if (!lud16Address) throw new Error('Profile has no Lightning Address configured');
+
+        const [name, domain] = lud16Address.split('@');
+        if (!domain) throw new Error('Only lud16 (Lightning Address) is supported');
+
+        const endpointUrl = `https://${domain}/.well-known/lnurlp/${name}`;
+        const res = await fetch(endpointUrl);
+        const lnData = await res.json();
+
+        if (!lnData.callback) throw new Error('Invalid LNURL response from provider');
+
+        // Populate cache for future opens
+        lnCache[npub] = { lud16: lud16Address, zapEndpoint: lnData.callback };
+        setLud16(lud16Address);
+        setZapEndpoint(lnData.callback);
+      } catch (err: any) {
+        setError(err.message || 'Failed to initialize payment');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchProfile();
+  }, [open, npub]);
+
+  const handleGenerateInvoice = async () => {
+    if (!zapEndpoint) return;
+    setLoading(true);
+    setError(null);
+
+    try {
+      const millisats = (amountSats || 0) * 1000;
+      const url = `${zapEndpoint}${zapEndpoint.includes('?') ? '&' : '?'}amount=${millisats}`;
+      const res = await fetch(url);
+      const data = await res.json();
+
+      if (data.pr) {
+        setInvoice(data.pr);
+        attemptWebLN(data.pr);
+      } else {
+        throw new Error(data.reason || 'Failed to generate invoice');
+      }
+    } catch (err: any) {
+      setError(err.message || 'Failed to generate invoice');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const attemptWebLN = async (pr: string) => {
+    try {
+      if (typeof window !== 'undefined' && (window as any).webln) {
+        await (window as any).webln.enable();
+        const response = await (window as any).webln.sendPayment(pr);
+        if (response?.preimage) {
+          message.success('Payment successful! Thank you for your support. ⚡');
+          onClose();
+        }
+      }
+    } catch (err) {
+      // Fallback: QR is already showing
+    }
+  };
+
+  const handleCopy = () => {
+    if (invoice) {
+      navigator.clipboard.writeText(invoice);
+      message.success('Invoice copied to clipboard');
+    }
+  };
+
+  return (
+    <Modal
+      title={
+        <span>
+          <ThunderboltOutlined style={{ color: '#fadb14', marginRight: 8 }} />
+          Support Formstr
+        </span>
+      }
+      open={open}
+      onCancel={onClose}
+      footer={null}
+      destroyOnClose={false}
+    >
+      <div style={{ textAlign: 'center', padding: '16px 0' }}>
+        {loading && !invoice && <Spin tip="Loading..." />}
+
+        {error && (
+          <Alert type="error" message={error} style={{ marginBottom: 16 }} />
+        )}
+
+        {!loading && !error && !invoice && (
+          <>
+            <Title level={5}>Send some sats to show your support! ⚡</Title>
+            <Text type="secondary" style={{ display: 'block', marginBottom: 16 }}>
+              Recipient: {lud16 || 'Resolving...'}
+            </Text>
+            <div style={{ marginBottom: 24 }}>
+              <div
+                style={{
+                  display: 'flex',
+                  flexWrap: 'wrap',
+                  gap: '8px',
+                  justifyContent: 'center',
+                }}
+              >
+                {[21, 100, 500, 1000, 5000].map((amt) => (
+                  <Button
+                    key={amt}
+                    type={amountSats === amt ? 'primary' : 'default'}
+                    onClick={() => setAmountSats(amt)}
+                    style={{
+                      borderRadius: '8px',
+                      padding: '4px 16px',
+                      height: 'auto',
+                      fontSize: '16px',
+                      fontWeight: amountSats === amt ? 'bold' : 'normal',
+                    }}
+                  >
+                    {amt.toLocaleString()}
+                  </Button>
+                ))}
+              </div>
+
+              <Divider style={{ margin: '16px 0', borderBlockColor: '#f0f0f0' }} />
+
+              <InputNumber
+                min={1}
+                value={amountSats}
+                onChange={(val) => setAmountSats(val)}
+                placeholder="Custom amount"
+                addonAfter="sats"
+                style={{ width: '100%', maxWidth: '300px' }}
+                size="large"
+              />
+            </div>
+            <Button
+              type="primary"
+              size="large"
+              onClick={handleGenerateInvoice}
+              loading={loading}
+              disabled={!zapEndpoint || !amountSats || amountSats <= 0}
+            >
+              Generate Invoice
+            </Button>
+          </>
+        )}
+
+        {invoice && (
+          <div>
+            <Title level={5}>Scan to Pay {amountSats} sats</Title>
+            <div style={{ margin: '24px 0' }}>
+              <QRCodeSVG value={invoice} size={220} />
+            </div>
+
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+                gap: 8,
+                flexWrap: 'wrap',
+                marginBottom: 16,
+              }}
+            >
+              <pre
+                style={{
+                  overflowX: 'auto',
+                  whiteSpace: 'nowrap',
+                  padding: 8,
+                  backgroundColor: '#f5f5f5',
+                  borderRadius: 4,
+                  fontSize: 12,
+                  maxWidth: '100%',
+                  margin: 0,
+                }}
+              >
+                {invoice}
+              </pre>
+              <Tooltip title="Copy invoice">
+                <Button
+                  icon={<CopyOutlined />}
+                  size="small"
+                  onClick={handleCopy}
+                  style={{ flexShrink: 0 }}
+                />
+              </Tooltip>
+            </div>
+
+            <Button onClick={() => attemptWebLN(invoice)} style={{ marginRight: 8 }}>
+              Open Wallet
+            </Button>
+            <Button type="default" onClick={() => setInvoice(null)}>
+              Back
+            </Button>
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+};

--- a/packages/formstr-support-us-button/src/index.tsx
+++ b/packages/formstr-support-us-button/src/index.tsx
@@ -1,0 +1,2 @@
+export { SupportUsButton } from './SupportUsButton';
+export { SupportUsModal, prefetchSupportInfo } from './SupportUsModal';

--- a/packages/formstr-support-us-button/tsconfig.json
+++ b/packages/formstr-support-us-button/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
@abh3po @geralt-debugs Adds a simple, built-in “Support Us” option so users can zap/donate to Formstr directly through the Lightning Network. This replaces the old external Geyser links with a smoother in-app NIP-57/LNURL flow.

### Architecture & Technical Implementation

* **New Package (`@formstr/support-us-button`)**: Built as a reusable React package inside the monorepo to handle the full donation flow.
* **Dynamic Nostr Resolution**: No hardcoded Lightning addresses. The component fetches the `lud16` endpoint from the official Formstr `npub` kind-0 profile event.
* **Monorepo Integration**: Hooked directly into `formstr-app` via `config/webpack.config.js`. It transpiles TSX on the fly, so there’s no separate build step and hot-reload works instantly.
* **Eager Prefetching**: Added a background cache (`prefetchSupportInfo`) that resolves the Lightning endpoint as soon as the component mounts. This keeps the modal fast with no loading states when clicked.

### Payment UX Flow

1. **WebLN First**: Detects WebLN (like Alby) and enables one-click browser payments.
2. **Fallback Option**: If WebLN isn’t available, it shows a QR code and a `lightning:<invoice>` deep link so users can pay through any wallet.

### UI Integration Points

The support feature is placed in two visible but non-intrusive spots:

1. **Global Header**: Replaces the Geyser link in the navigation dropdown. It’s positioned outside the Ant Design `<Menu>` so it doesn’t get hidden in the mobile overflow menu.
2. **Post-Publish Share Tab**: Adds a small inline link (` Enjoying Formstr? Support Us ⚡`) at the bottom of the ShareTab modal. It only appears after a user has successfully published a form.


https://github.com/user-attachments/assets/1967203e-5ccb-47ae-ad04-a4811944e41c

