### PR TITLE
fix(nip46): verify signed.pubkey matches expected user pubkey

### DIFF
--- a/packages/formstr-app/src/signer/nip46/index.ts
+++ b/packages/formstr-app/src/signer/nip46/index.ts
@@ -458,15 +458,26 @@ export class BunkerSigner implements Signer {
   async signEvent(event: EventTemplate): Promise<VerifiedEvent> {
     let resp = await this.sendRequest("sign_event", [JSON.stringify(event)]);
     let signed: NostrEvent = JSON.parse(resp);
-    if (verifyEvent(signed)) {
-      return signed;
-    } else {
+
+    if (!verifyEvent(signed)) {
       throw new Error(
         `event returned from bunker is improperly signed: ${JSON.stringify(
           signed
         )}`
       );
     }
+
+    // Ensure the signed event belongs to the expected user pubkey.
+    // Without this, a malicious bunker could return a signature from an
+    // attacker-controlled keypair and the client would publish as the user.
+    const expectedPubkey = await this.getPublicKey();
+    if (signed.pubkey !== expectedPubkey) {
+      throw new Error(
+        `bunker returned event with mismatched pubkey: expected ${expectedPubkey}, got ${signed.pubkey}`
+      );
+    }
+
+    return signed;
   }
 
   async nip04Encrypt(


### PR DESCRIPTION
## Summary

BunkerSigner.signEvent verified signatures via verifyEvent() but never checked that signed.pubkey matched the expected user pubkey. A malicious bunker could return a valid signature from an attacker-controlled keypair and the client would publish the event as the user — identity substitution.

## Fix

After verifyEvent(), call getPublicKey() to get the cached expected pubkey, then throw if signed.pubkey does not match it.

## Code change (packages/formstr-app/src/signer/nip46/index.ts)

Before:
```typescript
if (verifyEvent(signed)) {
  return signed;
} else {
  throw new Error(...);
}
```

After:
```typescript
if (!verifyEvent(signed)) {
  throw new Error(...);
}
const expectedPubkey = await this.getPublicKey();
if (signed.pubkey !== expectedPubkey) {
  throw new Error(
    `bunker returned event with mismatched pubkey: expected ${expectedPubkey}, got ${signed.pubkey}`
  );
}
return signed;
```

Fixes formstr-hq/nostr-forms#479