### PR TITLE
fix: defensive parsing in fetchFormEvents to prevent blank My Forms and stuck save spinner

### DIFF
--- a/packages/formstr-app/src/provider/MyFormsProvider.tsx
+++ b/packages/formstr-app/src/provider/MyFormsProvider.tsx
@@ -69,15 +69,25 @@ export const MyFormsProvider = ({ children }: { children: ReactNode }) => {
   const loadedForPubRef = useRef<string | null>(null);
   const fetchSubRef = useRef<{ close: () => void } | null>(null);
 
-  const fetchFormEvents = (forms: Tag[]) => {
+  const fetchFormEvents = (forms: unknown) => {
     fetchSubRef.current?.close();
 
     const initial = new Map<string, FormEventMetadata>();
     const formLookup = new Map<string, string>();
-    forms.forEach((formTag) => {
-      const [, formData, relay, secretData] = formTag;
+    const list = Array.isArray(forms) ? forms : [];
+    for (const formTag of list) {
+      if (
+        !Array.isArray(formTag) ||
+        formTag[0] !== "f" ||
+        typeof formTag[1] !== "string"
+      )
+        continue;
+      const formData = formTag[1] as string;
+      const relay = typeof formTag[2] === "string" ? formTag[2] : "";
+      const secretData = typeof formTag[3] === "string" ? formTag[3] : "";
       const [formPubkey, formId] = formData.split(":");
-      const [secretKey, viewKey] = secretData.split(":");
+      if (!formPubkey || !formId) continue;
+      const [secretKey = "", viewKey] = secretData.split(":");
       initial.set(formId, {
         event: null,
         secrets: { secretKey, viewKey },
@@ -86,11 +96,13 @@ export const MyFormsProvider = ({ children }: { children: ReactNode }) => {
         formId,
       });
       formLookup.set(`${formPubkey}:${formId}`, formId);
-    });
+    }
     setFormEvents(initial);
 
-    const dTags = forms.map((f) => f[1].split(":")[1]);
-    const pubkeys = forms.map((f) => f[1].split(":")[0]);
+    if (initial.size === 0) return;
+
+    const dTags = [...initial.values()].map((v) => v.formId);
+    const pubkeys = [...initial.values()].map((v) => v.formPubkey);
 
     fetchSubRef.current = pool.subscribeMany(
       getDefaultRelays(),


### PR DESCRIPTION
Closes #489

## Description
If the kind-14083 list had any entry that wasn't a clean 4-element array, the bare `forEach` in `fetchFormEvents` would throw on that entry. The throw was caught by the outer try/catch in `refreshForms`, but `setFormEvents` was never called -- so `formEvents` stayed empty. That caused two visible failures:

- My Forms list showed nothing.
- The "Saving to nostr profile" spinner after creating a form never resolved, because it reads from `formEvents` via `inMyForms()`.

## Changes

`fetchFormEvents` now validates each entry before processing it. Malformed or unexpected entries are skipped, and `setFormEvents` always runs -- so a bad entry from any source can't blank the whole list.

- Switched from `forEach` to a `for...of` loop with per-entry guards.
- `forms` parameter widened to `unknown` so invalid JSON parse results are also handled.
- `dTags` and `pubkeys` for `subscribeMany` are now derived from the already-validated `initial` map instead of from the raw input, removing a second potential crash point.

All valid entries from formstr.app and interoperating clients continue to load as before.

## How to test

1. Using a Nostr account, write a kind-14083 event that includes a 3-element entry (no 4th secrets field) mixed in with normal formstr.app entries.
2. Open My Forms -- the valid entries should load; the bad one is silently skipped.
3. Create a new form -- the save spinner should resolve to the checkmark once the publish completes.