### PR TITLE
fix: My Forms stuck loading forever after concurrent login-modal waits

### DIFF
--- a/packages/formstr-app/src/containers/Dashboard/FormCards/MyForms.tsx
+++ b/packages/formstr-app/src/containers/Dashboard/FormCards/MyForms.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import { FormEventCard } from "./FormEventCard";
 import { Spin, Card, Button, Divider } from "antd";
 import { LoadingOutlined, ReloadOutlined } from "@ant-design/icons";
@@ -7,8 +8,10 @@ import { useMyForms } from "../../../provider/MyFormsProvider";
 import DeleteFormTrigger from "./DeleteForm";
 import { makeFormNAddr, naddrUrl } from "../../../utils/utility";
 import { responsePath } from "../../../utils/formUtils";
+import EmptyScreen from "../../../components/EmptyScreen";
 
 export const MyForms = () => {
+  const { t } = useTranslation();
   const { formEvents, refreshing, deleteForm, retryForm } = useMyForms();
   const [retrying, setRetrying] = useState<Set<string>>(new Set());
   const navigate = useNavigate();
@@ -35,6 +38,12 @@ export const MyForms = () => {
             <LoadingOutlined style={{ fontSize: 48, color: "#F7931A" }} spin />
           }
         />
+      ) : null}
+      {!refreshing && formEvents.size === 0 ? (
+        // Without this, an empty list rendered nothing at all — which reads
+        // as a load that never finishes (e.g. right after deleting your last
+        // form from another Formstr client).
+        <EmptyScreen message={t("dashboard.myFormsEmpty")} />
       ) : null}
       {[...formEvents.values()]
         .sort((a, b) => {

--- a/packages/formstr-app/src/i18n/resources/en.ts
+++ b/packages/formstr-app/src/i18n/resources/en.ts
@@ -256,6 +256,7 @@ const resources = {
     localEmpty:
       "No forms found on this device. Start by choosing a template:",
     sharedEmpty: "No forms shared with you.",
+    myFormsEmpty: "No forms saved to your account yet.",
     encryptedFormsTitle: "Encrypted forms on this device",
     encryptedFormsDescription:
       "You have encrypted forms stored on this device. Login to access them.",

--- a/packages/formstr-app/src/provider/MyFormsProvider.tsx
+++ b/packages/formstr-app/src/provider/MyFormsProvider.tsx
@@ -206,7 +206,15 @@ export const MyFormsProvider = ({ children }: { children: ReactNode }) => {
 
       const event = await signer.signEvent({
         kind: KINDS.myFormsList,
-        created_at: Math.floor(Date.now() / 1000),
+        // Strictly supersede the event this write was derived from: kind 14083
+        // is replaceable, so two writes in the same second tie on created_at
+        // and relays keep the LOWEST id (NIP-01) — which can resurrect the
+        // stale copy. A plain "now" also loses silently to any newer-stamped
+        // list another client just published.
+        created_at: Math.max(
+          Math.floor(Date.now() / 1000),
+          (existing?.created_at ?? 0) + 1,
+        ),
         tags: [],
         content: encrypted,
       });
@@ -281,7 +289,14 @@ export const MyFormsProvider = ({ children }: { children: ReactNode }) => {
 
       const event = await signer.signEvent({
         kind: 14083,
-        created_at: Math.floor(Date.now() / 1000),
+        // Must strictly supersede the list we just read, or the delete can
+        // silently lose: a same-second tie resolves to the lowest event id
+        // (resurrecting the pre-delete list), and a list stamped later by
+        // another client outranks a plain "now" republish entirely.
+        created_at: Math.max(
+          Math.floor(Date.now() / 1000),
+          list.created_at + 1,
+        ),
         tags: [],
         content: await signer.nip44Encrypt!(
           userPub,

--- a/packages/formstr-app/src/signer/index.ts
+++ b/packages/formstr-app/src/signer/index.ts
@@ -34,6 +34,7 @@ class Signer {
   private signer: NostrSigner | null = null;
   private onChangeCallbacks: Set<() => void> = new Set();
   private loginModalCallback: (() => Promise<void>) | null = null;
+  private loginWait: Promise<void> | null = null;
 
   constructor() {
     this.restoreFromStorage();
@@ -142,9 +143,20 @@ class Signer {
     if (this.signer) return this.signer;
 
     if (this.loginModalCallback) {
-      console.log("GOING TO CALL LOGINMODALCALLBACK");
-      await this.loginModalCallback();
-      console.log("AFTER CALLING loginModal Callback", this.signer);
+      // Single-flight the modal wait. Concurrent getSigner() calls (e.g. the
+      // LocalForms and MyForms providers both loading at mount while the
+      // signer is still locked) used to invoke loginModalCallback() twice;
+      // the second invocation overwrote the first one's resolve/reject
+      // handlers in ProfileProvider, so the first caller's promise could
+      // never settle — its loader then held a "refreshing" flag forever
+      // (the My Forms section spun indefinitely). All concurrent callers
+      // must share ONE modal promise.
+      if (!this.loginWait) {
+        this.loginWait = this.loginModalCallback().finally(() => {
+          this.loginWait = null;
+        });
+      }
+      await this.loginWait;
       if (this.signer) return this.signer;
     }
 


### PR DESCRIPTION
## Description
After deleting a form (or sometimes just on page load), the "My Forms" section spins forever and never recovers, even though the relays have the correct, up-to-date form list.

## Root Cause
`signerManager.getSigner()` calls `loginModalCallback()` once **per caller**, but `ProfileProvider` only stores a single resolve/reject handler pair for the login modal.

When the signer is locked, `MyFormsProvider` and `LocalFormsProvider` both call `getSigner()` on the same render commit. The second call overwrites the first caller's handlers, so the first caller's promise never settles. Since `MyFormsProvider` sets `refreshing = true` before awaiting the signer, the spinner stays up forever, and its `isRefreshingRef` guard then swallows every later refresh attempt, nothing short of a hard reload recovers it.

## Fix

-  **Single-flight the login-modal promise** in `Signer.getSigner()`: the first caller creates the promise, concurrent callers await the same one, and it's cleared once settled. One modal, one handler pair, every caller wakes up.

- **Monotonic `created_at` on kind-14083 republishes**: kind 14083 is replaceable and NIP-01 breaks same-second ties by lowest event id, so a republish in the same second as the list it read could lose the tie and resurrect the pre-delete list. Both republish sites now use `created_at = max(now, previous + 1)` so the new list strictly supersedes the one it was derived from.

-  **Empty state for My Forms**, so "you have no forms" is distinguishable from "still loading".