### PR TITLE
rendering_sdk_issues_resolved

### DIFF
--- a/packages/formstr-sdk/docs/v1/design.md
+++ b/packages/formstr-sdk/docs/v1/design.md
@@ -1,5 +1,8 @@
 Formstr sdk is the tooling designed on top of the nostr protocol to help create forms that can be embedded into any website, software or usecase. This document outlines the basic api and functionality of the sdk.
 
+For the complete list of supported fields, their configuration, and response
+formats, see [Field types](./field-types.md).
+
 ## API
 
 ### Create a form

--- a/packages/formstr-sdk/docs/v1/field-types.md
+++ b/packages/formstr-sdk/docs/v1/field-types.md
@@ -1,0 +1,350 @@
+# Field types
+
+Formstr fields are stored as Nostr tags. The SDK normalizes those tags and
+uses the field's `renderElement` setting to choose the HTML control to render.
+
+The generated HTML is intentionally unstyled. An application embedding the
+SDK can add its own CSS without having to reimplement the form controls.
+
+## Field tag format
+
+A field tag has six values:
+
+```js
+[
+  "field",
+  "<field-id>",
+  "<primitive>",
+  "<label>",
+  "<JSON-encoded options>",
+  "<JSON-encoded configuration>",
+]
+```
+
+For example, a required date field is represented as:
+
+```js
+[
+  "field",
+  "arrival-date",
+  "text",
+  "When will you arrive?",
+  "[]",
+  '{"renderElement":"date","required":true}',
+]
+```
+
+When creating tags in JavaScript, use `JSON.stringify` for the options and
+configuration values:
+
+```js
+const field = (id, primitive, label, options, config) => [
+  "field",
+  id,
+  primitive,
+  label,
+  JSON.stringify(options),
+  JSON.stringify(config),
+];
+```
+
+## Supported types
+
+| `renderElement` | Primitive | Rendered control | Submitted value |
+| --- | --- | --- | --- |
+| `shortText` | `text` | Text input | String |
+| `paragraph` | `text` | Textarea | String |
+| `number` | `number` | Number input | Numeric string |
+| `radioButton` | `option` | Radio group | Selected option ID |
+| `checkboxes` | `option` | Checkbox group | Selected option IDs separated by `;` |
+| `dropdown` | `option` | Select menu | Selected option ID |
+| `date` | `text` | Date input | `YYYY-MM-DD` |
+| `time` | `text` | Time input | `h:mm AM/PM` |
+| `datetime` | `text` | Date and time input | Unix timestamp in seconds |
+| `rating` | `text` | Range input | JSON containing a normalized value |
+| `signature` | `text` | Signature payload textarea | String supplied by the application |
+| `fileUpload` | `text` | File input | String returned by `transformFile` |
+| `multipleChoiceGrid` | `grid` | One radio choice per row | JSON object of row and column IDs |
+| `checkboxGrid` | `grid` | Multiple checkbox choices per row | JSON object with `;`-separated column IDs |
+| `label` | `label` | Static content | No response value |
+
+### Supported configuration
+
+| Setting | Used by | Purpose |
+| --- | --- | --- |
+| `required` | Input fields and grids | Requires a value before the response is published |
+| `min`, `max`, `step` | `number` | Sets the native number input constraints |
+| `maxStars` | `rating` | Sets the rating scale; defaults to `5` |
+| `allowedTypes` | `fileUpload` | Sets the accepted MIME types, such as `image/*` |
+| `accept` | `fileUpload` | Sets one accepted MIME type when `allowedTypes` is not provided |
+| `multipleFiles` | `fileUpload` | Allows more than one file to be selected |
+| `allowMultiplePerRow` | Grid fields | Uses checkboxes when `true` and radio buttons when `false` |
+| `requiredRows` | `multipleChoiceGrid` | Marks specific rows as required in the generated HTML |
+
+## Text and number fields
+
+Text fields do not need options. Set `required` when the user must provide a
+value. Number fields can also use `min`, `max`, and `step`.
+
+```js
+const name = field("name", "text", "Your name", [], {
+  renderElement: "shortText",
+  required: true,
+});
+
+const notes = field("notes", "text", "Anything else we should know?", [], {
+  renderElement: "paragraph",
+});
+
+const guests = field("guests", "number", "Number of guests", [], {
+  renderElement: "number",
+  min: 1,
+  max: 10,
+  step: 1,
+});
+```
+
+## Choice fields
+
+Radio buttons, checkboxes, and dropdowns use an array of option tuples. Each
+tuple contains an option ID, a label, and an optional JSON-encoded option
+configuration.
+
+```js
+const attendanceOptions = [
+  ["yes", "Yes, I will attend"],
+  ["no", "No, I cannot attend"],
+  ["maybe", "Maybe"],
+];
+
+const attendance = field(
+  "attendance",
+  "option",
+  "Will you attend?",
+  attendanceOptions,
+  { renderElement: "radioButton", required: true },
+);
+
+const interests = field(
+  "interests",
+  "option",
+  "What are you interested in?",
+  [
+    ["nostr", "Nostr"],
+    ["lightning", "Lightning"],
+  ],
+  { renderElement: "checkboxes" },
+);
+
+const meal = field(
+  "meal",
+  "option",
+  "Meal preference",
+  [
+    ["standard", "Standard"],
+    ["vegetarian", "Vegetarian"],
+  ],
+  { renderElement: "dropdown", required: true },
+);
+```
+
+A radio button or dropdown submits one option ID. A checkbox group submits
+all selected option IDs joined with a semicolon, for example
+`"nostr;lightning"`.
+
+## Date and time fields
+
+```js
+const date = field("date", "text", "Booking date", [], {
+  renderElement: "date",
+  required: true,
+});
+
+const time = field("time", "text", "Preferred time", [], {
+  renderElement: "time",
+  required: true,
+});
+
+const startsAt = field("starts-at", "text", "Start date and time", [], {
+  renderElement: "datetime",
+  required: true,
+});
+```
+
+Date values remain in the browser's `YYYY-MM-DD` format. Time values are
+converted to Formstr's 12-hour format, and date-time values are converted to
+Unix timestamps in seconds before submission.
+
+## Rating fields
+
+`maxStars` defaults to `5`. The rendered range supports half-step ratings.
+
+```js
+const rating = field("rating", "text", "How was your experience?", [], {
+  renderElement: "rating",
+  maxStars: 5,
+});
+```
+
+Ratings are stored as a normalized value between `0` and `1`. For example, a
+rating of four out of five is submitted as:
+
+```json
+{"normalizedValue":0.8}
+```
+
+## Grid fields
+
+Grid options are an object with `columns` and `rows`. Both contain tuples of
+an ID, a label, and an optional JSON-encoded configuration.
+
+```js
+const gridOptions = {
+  columns: [
+    ["poor", "Poor"],
+    ["good", "Good"],
+    ["great", "Great"],
+  ],
+  rows: [
+    ["quality", "Quality"],
+    ["speed", "Speed"],
+  ],
+};
+
+const singleChoiceGrid = field(
+  "feedback",
+  "grid",
+  "Rate each area",
+  gridOptions,
+  {
+    renderElement: "multipleChoiceGrid",
+    allowMultiplePerRow: false,
+    required: true,
+  },
+);
+
+const checkboxGrid = field(
+  "notifications",
+  "grid",
+  "How should we contact you?",
+  {
+    columns: [
+      ["email", "Email"],
+      ["sms", "SMS"],
+    ],
+    rows: [
+      ["news", "News"],
+      ["reminders", "Reminders"],
+    ],
+  },
+  {
+    renderElement: "checkboxGrid",
+    allowMultiplePerRow: true,
+  },
+);
+```
+
+A multiple-choice grid stores one column ID for each answered row:
+
+```json
+{"quality":"great","speed":"good"}
+```
+
+A checkbox grid stores multiple column IDs as a semicolon-separated string:
+
+```json
+{"news":"email;sms","reminders":"sms"}
+```
+
+## Labels
+
+Labels add explanatory content to a form and do not produce a response value.
+
+```js
+const detailsHeading = field(
+  "details-heading",
+  "label",
+  "Please provide your booking details below.",
+  [],
+  { renderElement: "label" },
+);
+```
+
+## Signatures
+
+The SDK renders a textarea for a signature payload. It does not create a
+Nostr signature on the user's behalf. The embedding application is
+responsible for signing the required event and placing its serialized value
+in the field.
+
+```js
+const signature = field("signature", "text", "Signed confirmation", [], {
+  renderElement: "signature",
+  required: true,
+});
+```
+
+## File uploads
+
+The SDK renders the file input but leaves storage and encryption to the
+embedding application. Use `allowedTypes` to set the input's accepted MIME
+types.
+
+```js
+const attachment = field("attachment", "text", "Supporting document", [], {
+  renderElement: "fileUpload",
+  allowedTypes: ["image/*", "application/pdf"],
+});
+```
+
+Pass `transformFile` when attaching the submit listener. It should upload the
+file and return the string that will be stored in the response, usually
+JSON-encoded encrypted Blossom metadata.
+
+```js
+sdk.attachSubmitListener(form, signer, {
+  transformFile: async (file, field, currentForm) => {
+    const metadata = await uploadEncryptedFile(file, {
+      field,
+      form: currentForm,
+    });
+
+    return JSON.stringify(metadata);
+  },
+  onSuccess: ({ event }) => {
+    console.log("Response published", event.id);
+  },
+  onError: (error) => {
+    console.error("Could not submit response", error);
+  },
+});
+```
+
+The SDK does not include raw file bytes in a Nostr response. If a user selects
+a file and no `transformFile` callback is provided, submission fails with an
+error.
+
+## Rendering and submitting a form
+
+After fetching a form, call `renderHtml`, mount the generated HTML, and then
+attach the submit listener:
+
+```js
+const form = await sdk.fetchForm(naddr);
+
+sdk.renderHtml(form);
+document.querySelector("#form-container").innerHTML = form.html.form;
+
+sdk.attachSubmitListener(form, undefined, {
+  onSuccess: ({ event }) => {
+    console.log("Response published", event.id);
+  },
+  onError: (error) => {
+    console.error("Could not submit response", error);
+  },
+});
+```
+
+`attachSubmitListener` collects repeated checkbox and grid values, validates
+required fields, converts specialized values, signs the response, and
+publishes it to the relays listed by the form.

--- a/packages/formstr-sdk/src/sdk/FormstrSDK.ts
+++ b/packages/formstr-sdk/src/sdk/FormstrSDK.ts
@@ -20,13 +20,16 @@ import {
   NormalizedField,
   NormalizedForm,
   RelayPublishResult,
+  ResponseSubmission,
   SectionBlock,
+  SubmitListenerOptions,
   Tag,
 } from "./types.js";
 import { fetchFormTemplate, getDefaultRelays } from "./utils/fetchFormTemplate.js";
 import { stripHtml } from "./utils/helper.js";
 import { encodeNKeys } from "./utils/nkeys.js";
 import { pool } from "./pool.js";
+import { validateResponse } from "./validateResponse.js";
 
 const KIND_FORM = 30168;
 const KIND_MY_FORMS_LIST = 14083;
@@ -50,10 +53,7 @@ export class FormstrSDK {
   attachSubmitListener(
     form: NormalizedForm,
     signer?: FormsSigner,
-    callbacks?: {
-      onSuccess?: (result: { event: Event; relays: string[] }) => void;
-      onError?: (error: unknown) => void;
-    },
+    callbacks?: SubmitListenerOptions,
   ) {
     const formEl = document.getElementById(
       `form-${form.id}`,
@@ -61,25 +61,105 @@ export class FormstrSDK {
     if (!formEl)
       return;
 
-    formEl.addEventListener("submit", async (e) => {
+    formEl.addEventListener("submit", (e) => {
       e.preventDefault(); // prevent page reload
+      void (async () => {
+        try {
+          const values = await this.collectFormValues(
+            form,
+            new FormData(formEl),
+            callbacks?.transformFile,
+          );
+          validateResponse(form, values);
+          const result = await this.submit(form, values, signer);
 
-      // Collect form values
-      const formData = new FormData(formEl);
-      const values: Record<string, any> = {};
-      formData.forEach((v, k) => (values[k] = v));
-
-      try {
-        const result = await this.submit(form, values, signer);
-
-        callbacks?.onSuccess?.({
-          event: result,
-          relays: form.relays,
-        });
-      } catch (err) {
-        callbacks?.onError?.(err);
-      }
+          callbacks?.onSuccess?.({
+            event: result,
+            relays: form.relays,
+          });
+        } catch (err) {
+          callbacks?.onError?.(err);
+        }
+      })();
     });
+  }
+
+  private async collectFormValues(
+    form: NormalizedForm,
+    formData: FormData,
+    transformFile?: SubmitListenerOptions["transformFile"],
+  ): Promise<ResponseSubmission> {
+    const values: ResponseSubmission = {};
+
+    for (const fieldId of form.fieldOrder) {
+      const field = form.fields[fieldId];
+      if (!field || field.type === "label") continue;
+
+      if (field.type === "grid") {
+        const gridOptions = field.options as GridOptions | undefined;
+        const gridValue: Record<string, string> = {};
+        for (const [rowId] of gridOptions?.rows ?? []) {
+          const selected = formData.getAll(`${fieldId}_${rowId}`).map(String);
+          if (selected.length > 0) {
+            gridValue[rowId] = field.config.allowMultiplePerRow
+              ? selected.join(";")
+              : selected[0];
+          }
+        }
+        if (Object.keys(gridValue).length > 0) values[fieldId] = gridValue;
+        continue;
+      }
+
+      const entries = formData.getAll(fieldId);
+      if (entries.length === 0) continue;
+
+      if (field.config.renderElement === "fileUpload") {
+        const files = entries.filter(
+          (entry): entry is File => entry instanceof File && entry.size > 0,
+        );
+        if (files.length === 0) continue;
+        if (!transformFile) {
+          throw new Error(
+            `File upload field "${fieldId}" requires a transformFile callback`,
+          );
+        }
+        const uploaded = await Promise.all(
+          files.map((file) => transformFile(file, field, form)),
+        );
+        values[fieldId] = field.config.multipleFiles ? uploaded : uploaded[0];
+        continue;
+      }
+
+      let value: string | string[] =
+        field.config.renderElement === "checkboxes"
+          ? entries.map(String)
+          : String(entries[0]);
+      if (
+        field.config.renderElement === "datetime" &&
+        typeof value === "string"
+      ) {
+        const timestamp = new Date(value).getTime();
+        if (Number.isFinite(timestamp))
+          value = String(Math.floor(timestamp / 1000));
+      }
+      if (field.config.renderElement === "time" && typeof value === "string") {
+        const [hours = "0", minutes = "00"] = value.split(":");
+        const hour = Number(hours);
+        value = `${hour % 12 || 12}:${minutes} ${hour >= 12 ? "PM" : "AM"}`;
+      }
+      if (
+        field.config.renderElement === "rating" &&
+        typeof value === "string"
+      ) {
+        values[fieldId] = JSON.stringify({
+          normalizedValue: Number(value) / (field.config.maxStars ?? 5),
+        });
+        continue;
+      }
+      values[fieldId] = value;
+    }
+
+    return values;
   }
 
   async fetchForm(naddr: string, nkeys?: string): Promise<NormalizedForm> {
@@ -108,17 +188,18 @@ export class FormstrSDK {
       .forEach((t) => {
         const [_, fieldId, type, label, optionsStr, configStr] = t;
 
+        const parsedOptions = optionsStr ? JSON.parse(optionsStr) : undefined;
         fields[fieldId] = {
           id: fieldId,
           type,
           labelHtml: label,
-          options: optionsStr
-            ? JSON.parse(optionsStr).map((o: any[]) => ({
+          options: Array.isArray(parsedOptions)
+            ? parsedOptions.map((o: any[]) => ({
                 id: o[0],
                 labelHtml: stripHtml(o[1]),
                 config: o[2] ? JSON.parse(o[2]) : undefined,
               }))
-            : undefined,
+            : parsedOptions,
           config: configStr ? JSON.parse(configStr) : {},
         };
 
@@ -178,34 +259,145 @@ export class FormstrSDK {
 
   /** Render HTML form with submit wired using FormData */
   renderHtml(form: NormalizedForm): NormalizedForm {
-    const renderField = (field: NormalizedField) => {
-      if (field.type === "text") {
-        return `
-        <label>${field.labelHtml}</label>
-        <input type="text" name="${field.id}" />
-      `;
-      }
-
-      if (field.type === "option" && field.options) {
-        return `
-        <div class="option-group">
-          <div class="option-label">${field.labelHtml}</div>
-          ${field.options
+    const attr = (value: unknown) =>
+      String(value ?? "")
+        .replace(/&/g, "&amp;")
+        .replace(/"/g, "&quot;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;");
+    const inputAttributes = (field: NormalizedField) => {
+      const config = field.config ?? {};
+      return [
+        config.required ? "required" : "",
+        config.min !== undefined ? `min="${attr(config.min)}"` : "",
+        config.max !== undefined ? `max="${attr(config.max)}"` : "",
+        config.step !== undefined ? `step="${attr(config.step)}"` : "",
+      ]
+        .filter(Boolean)
+        .join(" ");
+    };
+    const renderOptions = (
+      field: NormalizedField,
+      inputType: "radio" | "checkbox",
+    ) => {
+      const options = Array.isArray(field.options) ? field.options : [];
+      return `
+        <fieldset class="option-group">
+          <legend class="option-label">${field.labelHtml}</legend>
+          ${options
             .map(
-              (opt) => `
+              (option) => `
               <label>
-                <input type="radio" name="${field.id}" value="${opt.id}" />
-                ${opt.labelHtml}
-              </label>
-            `,
+                <input type="${inputType}" name="${attr(
+                  field.id,
+                )}" value="${attr(option.id)}" ${
+                  field.config.required && inputType === "radio"
+                    ? "required"
+                    : ""
+                } />
+                ${option.labelHtml}
+              </label>`,
             )
             .join("")}
-        </div>
-      `;
+        </fieldset>`;
+    };
+    const renderField = (field: NormalizedField) => {
+      if (!field) return "";
+      const renderElement = field.config?.renderElement;
+      const attributes = inputAttributes(field);
+
+      if (field.type === "label" || renderElement === "label") {
+        return `<p class="form-label">${field.labelHtml}</p>`;
       }
 
-      if (field.type === "label") {
-        return `<p>${field.labelHtml}</p>`;
+      if (renderElement === "paragraph") {
+        return `
+        <label for="field-${attr(field.id)}">${field.labelHtml}</label>
+        <textarea id="field-${attr(field.id)}" name="${attr(
+          field.id,
+        )}" ${attributes}></textarea>`;
+      }
+
+      if (renderElement === "number") {
+        return `
+        <label for="field-${attr(field.id)}">${field.labelHtml}</label>
+        <input id="field-${attr(field.id)}" type="number" name="${attr(
+          field.id,
+        )}" ${attributes} />`;
+      }
+
+      if (renderElement === "checkboxes") {
+        return renderOptions(field, "checkbox");
+      }
+
+      if (
+        renderElement === "radioButton" ||
+        (field.type === "option" && !renderElement)
+      ) {
+        return renderOptions(field, "radio");
+      }
+
+      if (renderElement === "dropdown") {
+        const options = Array.isArray(field.options) ? field.options : [];
+        return `
+        <label for="field-${attr(field.id)}">${field.labelHtml}</label>
+        <select id="field-${attr(field.id)}" name="${attr(
+          field.id,
+        )}" ${attributes}>
+          <option value="">Select an option</option>
+          ${options
+            .map(
+              (option) =>
+                `<option value="${attr(option.id)}">${
+                  option.labelHtml
+                }</option>`,
+            )
+            .join("")}
+        </select>`;
+      }
+
+      if (["date", "time", "datetime"].includes(renderElement ?? "")) {
+        const htmlType =
+          renderElement === "datetime"
+            ? "datetime-local"
+            : renderElement ?? "text";
+        return `
+        <label for="field-${attr(field.id)}">${field.labelHtml}</label>
+        <input id="field-${attr(field.id)}" type="${htmlType}" name="${attr(
+          field.id,
+        )}" ${attributes} />`;
+      }
+
+      if (renderElement === "signature") {
+        return `
+        <label for="field-${attr(field.id)}">${field.labelHtml}</label>
+        <textarea id="field-${attr(field.id)}" name="${attr(
+          field.id,
+        )}" class="signature-input" ${attributes}></textarea>`;
+      }
+
+      if (renderElement === "fileUpload") {
+        const accepted =
+          field.config.allowedTypes ??
+          (field.config.accept ? [field.config.accept] : []);
+        return `
+        <label for="field-${attr(field.id)}">${field.labelHtml}</label>
+        <input id="field-${attr(field.id)}" type="file" name="${attr(
+          field.id,
+        )}" ${accepted.length ? `accept="${attr(accepted.join(","))}"` : ""} ${
+          field.config.multipleFiles ? "multiple" : ""
+        } ${attributes} />`;
+      }
+
+      if (renderElement === "rating") {
+        const maxStars = field.config.maxStars ?? 5;
+        return `
+        <label for="field-${attr(field.id)}">${field.labelHtml}</label>
+        <input id="field-${attr(field.id)}" type="range" name="${attr(
+          field.id,
+        )}" min="0.5" max="${attr(maxStars)}" step="0.5" ${
+          field.config.required ? "required" : ""
+        } />`;
       }
 
       if (field.type === "grid" && field.options) {
@@ -235,9 +427,15 @@ export class FormstrSDK {
                     <td>
                       <input
                         type="${inputType}"
-                        name="${field.id}_${row[0]}"
-                        value="${col[0]}"
-                        ${inputType === "radio" ? "" : ""}
+                        name="${attr(field.id)}_${attr(row[0])}"
+                        value="${attr(col[0])}"
+                        ${
+                          (field.config.required ||
+                            field.config.requiredRows?.includes(row[0])) &&
+                          inputType === "radio"
+                            ? "required"
+                            : ""
+                        }
                       />
                     </td>
                   `,
@@ -253,10 +451,22 @@ export class FormstrSDK {
       `;
       }
 
+      if (
+        field.type === "text" ||
+        renderElement === "shortText" ||
+        !renderElement
+      ) {
+        return `
+        <label for="field-${attr(field.id)}">${field.labelHtml}</label>
+        <input id="field-${attr(field.id)}" type="text" name="${attr(
+          field.id,
+        )}" ${attributes} />`;
+      }
+
       return "";
     };
 
-    const renderBlock = (block: any) => {
+    const renderBlock = (block: FormBlock) => {
       if (block.type === "intro") {
         return `
         <section class="form-section form-intro">
@@ -289,7 +499,7 @@ export class FormstrSDK {
       return "";
     };
 
-    const bodyHtml = form.blocks?.map(renderBlock).join("\n");
+    const bodyHtml = form.blocks?.map(renderBlock).join("\n") ?? "";
 
     // Neutral wrapper
     form.html = {
@@ -315,13 +525,13 @@ export class FormstrSDK {
     signer?: FormsSigner,
   ) {
     const responseTags: Tag[] = Object.entries(values).map(([fieldId, value]) => {
-      const field = form.fields[fieldId];
-      if (field?.type === "grid") {
+        const field = form.fields[fieldId];
+        if (field?.type === "grid") {
         const jsonValue = typeof value === "string" ? value : JSON.stringify(value);
-        return ["response", fieldId, jsonValue, "{}"];
-      }
-      if (Array.isArray(value)) value = value.join(";");
-      return ["response", fieldId, value, "{}"];
+          return ["response", fieldId, jsonValue, "{}"];
+        }
+        if (Array.isArray(value)) value = value.join(";");
+        return ["response", fieldId, value, "{}"];
     });
 
     let content: string;

--- a/packages/formstr-sdk/src/sdk/main.ts
+++ b/packages/formstr-sdk/src/sdk/main.ts
@@ -11,5 +11,7 @@ export type {
     MyFormSummary,
     NormalizedForm,
     NormalizedField,
-    SectionBlock
+    SectionBlock,
+    SubmitListenerOptions,
+    GridOptions,
 } from "./types.js";

--- a/packages/formstr-sdk/src/sdk/types.ts
+++ b/packages/formstr-sdk/src/sdk/types.ts
@@ -44,7 +44,7 @@ export interface NormalizedField {
   id: string;
   type: string;
   labelHtml: string;
-  options?: NormalizedOption[];
+  options?: NormalizedOption[] | GridOptions;
   config: FieldConfig;
   primitive?: "string" | "number" | "boolean";
 }
@@ -64,6 +64,13 @@ export interface FieldConfig {
   pattern?: string;
   allowMultiplePerRow?: boolean;
   requiredRows?: string[];
+  min?: number;
+  max?: number;
+  step?: number;
+  maxStars?: number;
+  accept?: string;
+  allowedTypes?: string[];
+  multipleFiles?: boolean;
 }
 
 export interface GridOptions {
@@ -91,7 +98,7 @@ export interface SectionData {
 }
 
 export interface ResponseSubmission {
-  [fieldId: string]: string | string[];
+  [fieldId: string]: string | string[] | Record<string, string | string[]>;
 }
 
 export type Tag = string[];
@@ -115,7 +122,27 @@ export type RenderElement =
   | "datetime"
   | "signature"
   | "fileUpload"
-  | "label";
+  | "label"
+  | "multipleChoiceGrid"
+  | "checkboxGrid"
+  | "rating";
+
+export interface SubmitListenerOptions {
+  onSuccess?: (result: {
+    event: import("nostr-tools").Event;
+    relays: string[];
+  }) => void;
+  onError?: (error: unknown) => void;
+  /**
+   * Uploads a selected file and returns the response value to publish (usually
+   * encrypted Blossom metadata). File inputs fail clearly when this is absent.
+   */
+  transformFile?: (
+    file: File,
+    field: NormalizedField,
+    form: NormalizedForm,
+  ) => Promise<string>;
+}
 
 export interface FormField {
   label: string;

--- a/packages/formstr-sdk/src/sdk/validateResponse.ts
+++ b/packages/formstr-sdk/src/sdk/validateResponse.ts
@@ -10,13 +10,24 @@ export function validateResponse(
     // Grid validation
     if (field.type === "grid" && field.config.required) {
       const gridOptions = field.options as unknown as GridOptions;
-      const responses = values[id]
-        ? (typeof values[id] === "string" ? JSON.parse(values[id] as string) : values[id])
+      const storedValue = values[id];
+      const responses: Record<string, string | string[]> = storedValue
+        ? typeof storedValue === "string"
+          ? (JSON.parse(storedValue) as Record<string, string | string[]>)
+          : Array.isArray(storedValue)
+          ? {}
+          : storedValue
         : {};
 
       for (const [rowId] of gridOptions.rows) {
-        if (!responses[rowId] || responses[rowId] === "") {
-          throw new Error(`Required grid row missing: ${field.labelHtml} - ${rowId}`);
+        if (
+          !responses[rowId] ||
+          responses[rowId] === "" ||
+          responses[rowId].length === 0
+        ) {
+          throw new Error(
+            `Required grid row missing: ${field.labelHtml} - ${rowId}`,
+          );
         }
       }
     }


### PR DESCRIPTION
when I was doing Adding form integrations booking page of nostr-calendar I found some places where Formstr-SDK does not fully support the rendering all available form field types. so I added them 

- Added rendering support for:
  - Text
  - Paragraph
  - Number
  - Radio
  - Checkboxes
  - Dropdown
  - Date
  - Time
  - DateTime
  - Rating
  - Signature
  - File Upload
  - Label
  - Grids
- Fixed checkbox and grid response collection.
- Added conversion for date, time, datetime, and rating field values.
- Added `transformFile` for safe handling of external file uploads.